### PR TITLE
Feature/deprecate native advertising id apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * Android's manifest configuration `com.batch.flutter.use_gaid` has been removed.
   * iOS's property `canUseIDFA` from `BatchPluginConfiguration` is now deprecated and does nothing.
   * iOS's Info.plist property `BatchFlutterCanUseIDFA` has been removed.
-  * You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method.
+  * You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method. Batch will persist it across starts.
 * Added `setEmail(String? email)` method to `BatchUserDataEditor`. This requires to have a user identifier registered or to call the `setIdentifier` method on the editor instance beforehand.
 * Added `setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state)` method to `BatchUserDataEditor`. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@
 
 **User**
 
-* Removed automatic collection of the advertising id. You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method.
+* Removed automatic collection of the advertising id:
+  * Android's Methods `setCanUseAdvertisingID` and `canUseAdvertisingID` from `BatchPluginConfiguration` are now deprecated and do nothing.
+  * Android's manifest configuration `com.batch.flutter.use_gaid` has been removed.
+  * iOS's property `canUseIDFA` from `BatchPluginConfiguration` is now deprecated and does nothing.
+  * iOS's Info.plist property `BatchFlutterCanUseIDFA` has been removed.
+  * You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method.
 * Added `setEmail(String? email)` method to `BatchUserDataEditor`. This requires to have a user identifier registered or to call the `setIdentifier` method on the editor instance beforehand.
 * Added `setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state)` method to `BatchUserDataEditor`. 
 

--- a/android/src/main/java/com/batch/batch_flutter/BatchPluginConfiguration.java
+++ b/android/src/main/java/com/batch/batch_flutter/BatchPluginConfiguration.java
@@ -15,7 +15,6 @@ import com.batch.android.Config;
 public class BatchPluginConfiguration {
 
     private static final String APIKEY_MANIFEST_KEY = "com.batch.flutter.apikey";
-    private static final String GAID_MANIFEST_KEY = "com.batch.flutter.use_gaid";
     private static final String ADVANCED_INFO_MANIFEST_KEY = "com.batch.flutter.use_advanced_device_information";
     private static final String INITIAL_DND_STATE_MANIFEST_KEY = "com.batch.flutter.do_not_disturb_initial_state";
 
@@ -23,8 +22,6 @@ public class BatchPluginConfiguration {
 
     @Nullable
     private String apiKey;
-
-    private boolean canUseAdvertisingID = true;
 
     private boolean canUseAdvancedDeviceInformation = true;
 
@@ -42,7 +39,6 @@ public class BatchPluginConfiguration {
 
         final ManifestReader manifestReader = new ManifestReader(context);
         apiKey = manifestReader.readString(APIKEY_MANIFEST_KEY, null);
-        canUseAdvertisingID = manifestReader.readBoolean(GAID_MANIFEST_KEY, true);
         canUseAdvancedDeviceInformation = manifestReader.readBoolean(ADVANCED_INFO_MANIFEST_KEY, true);
         initialDoNotDisturbState = manifestReader.readBoolean(INITIAL_DND_STATE_MANIFEST_KEY, false);
     }
@@ -58,7 +54,6 @@ public class BatchPluginConfiguration {
         }
         Config batchConfig = new Config(apiKey);
         batchConfig.setCanUseAdvancedDeviceInformation(canUseAdvancedDeviceInformation);
-        batchConfig.setCanUseAdvertisingID(canUseAdvertisingID);
         return batchConfig;
     }
 
@@ -74,12 +69,26 @@ public class BatchPluginConfiguration {
         return this;
     }
 
+    /**
+     * Can Batch use Advertising ID
+     * Batch doesn't collects Android Advertising Identifier anymore.
+     *
+     * @deprecated This method does nothing, please stop using it.
+     * @return Always return false.
+     */
+    @Deprecated
     public boolean canUseAdvertisingID() {
-        return canUseAdvertisingID;
+        return false;
     }
 
+    /**
+     * Batch doesn't support Android Advertising Identifier anymore.
+     *
+     * @param canUseAdvertisingID This parameter does nothing.
+     * @deprecated This method does nothing, please stop using it.
+     */
+    @Deprecated
     public BatchPluginConfiguration setCanUseAdvertisingID(boolean canUseAdvertisingID) {
-        this.canUseAdvertisingID = canUseAdvertisingID;
         return this;
     }
 

--- a/ios/Classes/BatchPluginConfiguration.swift
+++ b/ios/Classes/BatchPluginConfiguration.swift
@@ -3,13 +3,12 @@ import Batch
 
 fileprivate struct PlistKeys {
     static let APIKey = "BatchFlutterAPIKey"
-    static let canUseIDFA = "BatchFlutterCanUseIDFA"
     static let canUseAdvancedDeviceInformation = "BatchFlutterCanUseAdvancedDeviceInformation"
     static let initialDnDState = "BatchFlutterDoNotDisturbInitialState"
 }
 
 /**
- Manages Batch's Flutter plugin confgugration. Do not instantiate this directly, use BatchFlutterPlugin to get an instance: your changes will otherwise be ignored.
+ Manages Batch's Flutter plugin configuration. Do not instantiate this directly, use BatchFlutterPlugin to get an instance: your changes will otherwise be ignored.
  
  This class' default values are initialized using your Info.plist settings, if any.
  */
@@ -17,7 +16,10 @@ fileprivate struct PlistKeys {
 public class BatchPluginConfiguration: NSObject {
     
     public var APIKey: String? = nil
+
+    @available(*, deprecated, message: "As Batch has removed support for automatic IDFA collection, this property does nothing.")
     public var canUseIDFA: Bool = false
+
     public var canUseAdvancedDeviceInformation: Bool = true
     public var initialDoNotDisturbState: Bool = false
     
@@ -38,7 +40,6 @@ public class BatchPluginConfiguration: NSObject {
         didReadInfoPlist = true
         
         APIKey = PlistReader.readString(key: PlistKeys.APIKey)
-        canUseIDFA = PlistReader.readBoolean(key: PlistKeys.canUseIDFA, fallbackValue: canUseIDFA)
         canUseAdvancedDeviceInformation = PlistReader.readBoolean(key: PlistKeys.canUseAdvancedDeviceInformation, fallbackValue: canUseAdvancedDeviceInformation)
         initialDoNotDisturbState = PlistReader.readBoolean(key: PlistKeys.initialDnDState, fallbackValue: initialDoNotDisturbState)
     }
@@ -47,7 +48,6 @@ public class BatchPluginConfiguration: NSObject {
     internal func apply() -> Bool {
         if let APIKey = APIKey, APIKey.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 {
             actualAPIKey = APIKey
-            Batch.setUseIDFA(canUseIDFA)
             Batch.setUseAdvancedDeviceInformation(canUseAdvancedDeviceInformation)
             BatchMessaging.doNotDisturb = initialDoNotDisturbState
             return true


### PR DESCRIPTION

  * Android's Methods `setCanUseAdvertisingID` and `canUseAdvertisingID` from `BatchPluginConfiguration` are now deprecated and do nothing.
  * Android's manifest configuration `com.batch.flutter.use_gaid` has been removed.
  * iOS's property `canUseIDFA` from `BatchPluginConfiguration` is now deprecated and does nothing.
  * iOS's Info.plist property `BatchFlutterCanUseIDFA` has been removed.
