### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * Android's manifest configuration `com.batch.flutter.use_gaid` has been removed.
   * iOS's property `canUseIDFA` from `BatchPluginConfiguration` is now deprecated and does nothing.
   * iOS's Info.plist property `BatchFlutterCanUseIDFA` has been removed.
-  * You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method.
+  * You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method. Batch will persist it across starts.
 * Added `setEmail(String? email)` method to `BatchUserDataEditor`. This requires to have a user identifier registered or to call the `setIdentifier` method on the editor instance beforehand.
 * Added `setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state)` method to `BatchUserDataEditor`. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UPCOMING
+## 1.4.0
 
 **Plugin**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## UPCOMING
+
+**Plugin**
+
+* Dart 2.15+ is now required.
+* Updated Batch to 1.21.0. 
+* Batch now compiles with and targets SDK 34 (Android 14). 
+* Xcode 15.1 required if your project uses bitcode.
+
+**User**
+
+* Added `setEmail(String? email)` method to `BatchUserDataEditor`. This requires to have a user identifier registered or to call the `setIdentifier` method on the editor instance beforehand.
+* Added `setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state)` method to `BatchUserDataEditor`. 
+
+**Inbox**
+
+* Added `hasLandingMessage` property to `BatchInboxNotificationContent`.
+* Added `displayNotificationLandingMessage(BatchInboxNotificationContent notification)` method to `BatchInboxFetcher`.  
+
+  
 ## 1.3.0
 
 **Plugin**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Dart 2.15+ is now required.
 * Updated Batch to 1.21.0. 
-* Batch now compiles with and targets SDK 34 (Android 14). 
-* Xcode 15.1 required if your project uses bitcode.
+* Batch requires iOS 12.0 or higher.
+* Batch now compiles with and targets SDK 34 (Android 14).
 
 **User**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 **User**
 
+* Removed automatic collection of the advertising id. You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method.
 * Added `setEmail(String? email)` method to `BatchUserDataEditor`. This requires to have a user identifier registered or to call the `setIdentifier` method on the editor instance beforehand.
 * Added `setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state)` method to `BatchUserDataEditor`. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@
 
 **User**
 
-* Removed automatic collection of the advertising id. You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method.
+* Removed automatic collection of the advertising id:
+  * Android's Methods `setCanUseAdvertisingID` and `canUseAdvertisingID` from `BatchPluginConfiguration` are now deprecated and do nothing.
+  * Android's manifest configuration `com.batch.flutter.use_gaid` has been removed.
+  * iOS's property `canUseIDFA` from `BatchPluginConfiguration` is now deprecated and does nothing.
+  * iOS's Info.plist property `BatchFlutterCanUseIDFA` has been removed.
+  * You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method.
 * Added `setEmail(String? email)` method to `BatchUserDataEditor`. This requires to have a user identifier registered or to call the `setIdentifier` method on the editor instance beforehand.
 * Added `setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state)` method to `BatchUserDataEditor`. 
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The Batch Flutter Plugin requires Flutter 2 and Dart 2.12 or higher.
 As this plugin is built over Batch's Native SDKs, their respective Android and iOS requirements apply.
 
 # Documentation
-- [Setup guide](https://flutter-doc-preview.batchers.vercel.app/flutter/prerequisites): start your implementation here!
+- [Setup guide](https://doc.batch.com/flutter/prerequisites): start your implementation here!
 - [Help center](https://help.batch.com/en/): answers to most questions you may have during the integration
-- [API reference](https://flutter-doc-preview.batchers.vercel.app/flutter-dart-api-reference/index.html): this documents each of the classes and methods in the Batch Flutter Plugin
+- [API reference](https://doc.batch.com/flutter-dart-api-reference/index.html): this documents each of the classes and methods in the Batch Flutter Plugin
 
 You may also find this guide useful to review after integration to make sure you're ready to go live: [How can I test the integration on iOS?](https://help.batch.com/en/articles/2669866-how-can-i-test-the-integration-on-ios) / [How can I test the integration on Android?](https://help.batch.com/en/articles/2672749-how-can-i-test-the-integration-on-android)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.2.0'
     }
 }
 
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.batch.batch_flutter"
     compileSdkVersion 34
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 
     dependencies {
         //noinspection GradleDynamicVersion
-        implementation 'com.batch.android:batch-sdk:1.19.+'
+        api 'com.batch.android:batch-sdk:1.20.+'
 
         implementation 'androidx.appcompat:appcompat:1.2.0'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,8 +41,8 @@ android {
     }
 
     dependencies {
+        api 'com.batch.android:batch-sdk:1.21.+'
         //noinspection GradleDynamicVersion
-        api 'com.batch.android:batch-sdk:1.20.+'
 
         implementation 'androidx.appcompat:appcompat:1.2.0'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 16

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.batch.batch_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android/src/main/java/com/batch/batch_flutter/BatchFlutterPlugin.java
+++ b/android/src/main/java/com/batch/batch_flutter/BatchFlutterPlugin.java
@@ -37,7 +37,7 @@ public class BatchFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
 
     private static final String PLUGIN_VERSION_SYSTEM_PROPERTY = "batch.plugin.version";
 
-    private static final String PLUGIN_VERSION = "Flutter/1.3.0";
+    private static final String PLUGIN_VERSION = "Flutter/1.4.0";
 
     private final static BatchPluginConfiguration configuration = new BatchPluginConfiguration();
 

--- a/android/src/main/java/com/batch/batch_flutter/BatchPluginConfiguration.java
+++ b/android/src/main/java/com/batch/batch_flutter/BatchPluginConfiguration.java
@@ -15,7 +15,6 @@ import com.batch.android.Config;
 public class BatchPluginConfiguration {
 
     private static final String APIKEY_MANIFEST_KEY = "com.batch.flutter.apikey";
-    private static final String GAID_MANIFEST_KEY = "com.batch.flutter.use_gaid";
     private static final String ADVANCED_INFO_MANIFEST_KEY = "com.batch.flutter.use_advanced_device_information";
     private static final String INITIAL_DND_STATE_MANIFEST_KEY = "com.batch.flutter.do_not_disturb_initial_state";
 
@@ -23,8 +22,6 @@ public class BatchPluginConfiguration {
 
     @Nullable
     private String apiKey;
-
-    private boolean canUseAdvertisingID = true;
 
     private boolean canUseAdvancedDeviceInformation = true;
 
@@ -42,7 +39,6 @@ public class BatchPluginConfiguration {
 
         final ManifestReader manifestReader = new ManifestReader(context);
         apiKey = manifestReader.readString(APIKEY_MANIFEST_KEY, null);
-        canUseAdvertisingID = manifestReader.readBoolean(GAID_MANIFEST_KEY, true);
         canUseAdvancedDeviceInformation = manifestReader.readBoolean(ADVANCED_INFO_MANIFEST_KEY, true);
         initialDoNotDisturbState = manifestReader.readBoolean(INITIAL_DND_STATE_MANIFEST_KEY, false);
     }
@@ -58,7 +54,6 @@ public class BatchPluginConfiguration {
         }
         Config batchConfig = new Config(apiKey);
         batchConfig.setCanUseAdvancedDeviceInformation(canUseAdvancedDeviceInformation);
-        batchConfig.setCanUseAdvertisingID(canUseAdvertisingID);
         return batchConfig;
     }
 
@@ -74,12 +69,26 @@ public class BatchPluginConfiguration {
         return this;
     }
 
+    /**
+     * Can Batch use Advertising ID
+     * Batch doesn't collects Android Advertising Identifier anymore.
+     *
+     * @deprecated This method does nothing, please stop using it.
+     * @return Always return false.
+     */
+    @Deprecated
     public boolean canUseAdvertisingID() {
-        return canUseAdvertisingID;
+        return false;
     }
 
+    /**
+     * Batch doesn't support Android Advertising Identifier anymore.
+     *
+     * @param canUseAdvertisingID This parameter does nothing.
+     * @deprecated This method does nothing, please stop using it.
+     */
+    @Deprecated
     public BatchPluginConfiguration setCanUseAdvertisingID(boolean canUseAdvertisingID) {
-        this.canUseAdvertisingID = canUseAdvertisingID;
         return this;
     }
 

--- a/android/src/main/java/com/batch/batch_flutter/interop/Action.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/Action.java
@@ -38,6 +38,7 @@ enum Action
     INBOX_MARK_AS_READ("inbox.markAsRead"),
     INBOX_MARK_ALL_AS_READ("inbox.markAllAsRead"),
     INBOX_MARK_AS_DELETED("inbox.markAsDeleted"),
+    INBOX_DISPLAY_LANDING("inbox.displayLandingMessage"),
 
     /// For testing
     ECHO("echo");

--- a/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
@@ -136,6 +136,7 @@ public class BatchBridge {
             case INBOX_MARK_AS_READ:
             case INBOX_MARK_ALL_AS_READ:
             case INBOX_MARK_AS_DELETED:
+            case INBOX_DISPLAY_LANDING:
                 return inboxBridge.doAction(action, parameters, activity);
 
             case ECHO:

--- a/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
@@ -293,6 +293,18 @@ public class BatchBridge {
                         }
                         break;
                     }
+                    case "SET_ATTRIBUTION_ID": {
+                        Object value = operationDescription.get("value");
+
+                        if (value != null && !(value instanceof String)) {
+                            Log.e("Batch Bridge", "Invalid SET_ATTRIBUTION_ID value: it can only be a string or null");
+                            // Invalid value, continue. NULL is allowed though
+                            continue;
+                        }
+
+                        editor.setAttributionIdentifier((String) value);
+                        break;
+                    }
                     case "SET_ATTRIBUTE":
                         String key = getTypedParameter(operationDescription, "key", String.class);
                         String type = getTypedParameter(operationDescription, "type", String.class);

--- a/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
@@ -37,7 +37,7 @@ import java.util.Set;
 public class BatchBridge {
     private static final String BRIDGE_VERSION_ENVIRONEMENT_VAR = "batch.bridge.version";
 
-    private static final String BRIDGE_VERSION = "Bridge/1.2";
+    private static final String BRIDGE_VERSION = "Bridge/1.3";
 
     private static final InboxBridge inboxBridge = new InboxBridge();
 

--- a/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 
 import com.batch.android.Batch;
 import com.batch.android.BatchAttributesFetchListener;
+import com.batch.android.BatchEmailSubscriptionState;
 import com.batch.android.BatchEventData;
 import com.batch.android.BatchMessage;
 import com.batch.android.BatchOptOutResultListener;
@@ -268,6 +269,28 @@ public class BatchBridge {
                         }
 
                         editor.setIdentifier((String) value);
+                        break;
+                    }
+                    case "SET_EMAIL": {
+                        Object value = operationDescription.get("value");
+
+                        if (value != null && !(value instanceof String)) {
+                            // Invalid value, continue. NULL is allowed though
+                            continue;
+                        }
+
+                        editor.setEmail((String) value);
+                        break;
+                    }
+                    case "SET_EMAIL_MARKETING_SUBSCRIPTION": {
+                        Object value = operationDescription.get("value");
+                        if ("subscribed".equals(value)) {
+                            editor.setEmailMarketingSubscriptionState(BatchEmailSubscriptionState.SUBSCRIBED);
+                        } else if ("unsubscribed".equals(value)) {
+                            editor.setEmailMarketingSubscriptionState(BatchEmailSubscriptionState.UNSUBSCRIBED);
+                        } else {
+                            Log.e("Batch Bridge", "Invalid SET_EMAIL_MARKETING_SUBSCRIPTION value: it can only be `subscribed` or `unsubscribed`.");
+                        }
                         break;
                     }
                     case "SET_ATTRIBUTE":

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -27,11 +27,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 34
-
+    namespace "com.batch.batch_flutter_example"
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.batch.batch_flutter_example"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,13 +26,13 @@ apply plugin: 'com.google.gms.google-services'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.batch.batch_flutter_example"
         minSdkVersion 16
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.batch.batch_flutter_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:name=".ExampleApplication"
         android:label="batch_flutter_example"

--- a/example/android/app/src/main/java/com/batch/batch_flutter_example/MainActivity.java
+++ b/example/android/app/src/main/java/com/batch/batch_flutter_example/MainActivity.java
@@ -1,6 +1,23 @@
 package com.batch.batch_flutter_example;
 
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import com.batch.android.Batch;
+
 import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+    }
+
+    @Override
+    protected void onNewIntent(@NonNull Intent intent) {
+        super.onNewIntent(intent);
+        Batch.onNewIntent(this, intent);
+    }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
     }
 }
@@ -25,6 +25,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,22 +1,23 @@
 PODS:
-  - Batch (1.19.2)
+  - Batch (1.20.0)
   - batch_flutter (0.0.5):
-    - Batch (~> 1.19.2)
+    - Batch (~> 1.20.0)
     - Flutter
   - batch_flutter/Tests (0.0.5):
-    - Batch (~> 1.19.2)
+    - Batch (~> 1.20.0)
     - Flutter
   - BatchExtension (3.0.3)
   - Flutter (1.0.0)
-  - shared_preferences_ios (0.0.1):
+  - shared_preferences_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - batch_flutter (from `.symlinks/plugins/batch_flutter/ios`)
   - batch_flutter/Tests (from `.symlinks/plugins/batch_flutter/ios`)
   - BatchExtension
   - Flutter (from `Flutter`)
-  - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -28,15 +29,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/batch_flutter/ios"
   Flutter:
     :path: Flutter
-  shared_preferences_ios:
-    :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  Batch: 9c0096b1149eaeee1d084c62ac60edd5d764dccd
-  batch_flutter: 963fd7712365d4cbeb4a9dcb9271a4726965d8d9
+  Batch: a9946fcb8c9132c86e7c3e1245532e41d32ade5b
+  batch_flutter: b604625d295a26282bedad077dae607758646750
   BatchExtension: 49d5c330811e2afdd4a144a3a4917ac07b8e82f3
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
 
 PODFILE CHECKSUM: 17700ccd4c3daf95a2f6f45716a2dd4688334329
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Batch (1.21.0)
-  - batch_flutter (0.0.5):
+  - batch_flutter (0.0.6):
     - Batch (~> 1.21.0)
     - Flutter
-  - batch_flutter/Tests (0.0.5):
+  - batch_flutter/Tests (0.0.6):
     - Batch (~> 1.21.0)
     - Flutter
   - BatchExtension (3.0.3)
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Batch: 977a9b7aed7fbbf2fe22476f4cea712e94ded79d
-  batch_flutter: fd3f7461df9f8e95e0cb38eac45ced478edbd254
+  batch_flutter: 830f22063e5915f5e53a2e239354659fac0e94f8
   BatchExtension: 49d5c330811e2afdd4a144a3a4917ac07b8e82f3
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Batch (1.20.0)
+  - Batch (1.21.0)
   - batch_flutter (0.0.5):
-    - Batch (~> 1.20.0)
+    - Batch (~> 1.21.0)
     - Flutter
   - batch_flutter/Tests (0.0.5):
-    - Batch (~> 1.20.0)
+    - Batch (~> 1.21.0)
     - Flutter
   - BatchExtension (3.0.3)
   - Flutter (1.0.0)
@@ -33,12 +33,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  Batch: a9946fcb8c9132c86e7c3e1245532e41d32ade5b
-  batch_flutter: b604625d295a26282bedad077dae607758646750
+  Batch: 977a9b7aed7fbbf2fe22476f4cea712e94ded79d
+  batch_flutter: fd3f7461df9f8e95e0cb38eac45ced478edbd254
   BatchExtension: 49d5c330811e2afdd4a144a3a4917ac07b8e82f3
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
 
-PODFILE CHECKSUM: 17700ccd4c3daf95a2f6f45716a2dd4688334329
+PODFILE CHECKSUM: e9468ff7667c6b6034c38e8cfa6486c0b577f92f
 
 COCOAPODS: 1.11.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -595,7 +595,7 @@
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -913,7 +913,7 @@
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -940,7 +940,7 @@
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/example/ios/Runner/Base.lproj/Main.storyboard
+++ b/example/ios/Runner/Base.lproj/Main.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Flutter View Controller-->
@@ -14,13 +16,14 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-16" y="-23"/>
         </scene>
     </scenes>
 </document>

--- a/example/lib/batch_store/ui/inbox/inbox_notification_row_item.dart
+++ b/example/lib/batch_store/ui/inbox/inbox_notification_row_item.dart
@@ -3,16 +3,19 @@ import 'package:flutter/material.dart';
 
 typedef InboxMarkAsReadCallback = void Function();
 typedef InboxDeleteCallback = void Function();
+typedef InboxDisplayLandingCallback = void Function();
 
 class InboxNotificationRowItem extends StatelessWidget {
   const InboxNotificationRowItem(
       {required this.notification,
       required this.onMarkAsRead,
+      required this.onDisplayLandingMessage,
       required this.onDelete});
 
   final BatchInboxNotificationContent notification;
   final InboxMarkAsReadCallback onMarkAsRead;
   final InboxDeleteCallback onDelete;
+  final InboxDisplayLandingCallback onDisplayLandingMessage;
 
   static const int menuMarkAsReadItem = 1;
   static const int menuDeleteItem = 2;
@@ -51,39 +54,44 @@ class InboxNotificationRowItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 20, horizontal: 10),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        notification.title ?? "",
-                        style: _notificationTitleStyle,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onDisplayLandingMessage,
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          notification.title ?? "",
+                          style: _notificationTitleStyle,
+                        ),
                       ),
-                    ),
-                    if (notification.isUnread)
-                      Container(
-                          height: 8,
-                          width: 8,
-                          decoration: BoxDecoration(
-                              color: Colors.blue, shape: BoxShape.circle)),
-                  ],
-                ),
-                Padding(padding: const EdgeInsets.symmetric(vertical: 6)),
-                Text(notification.body),
-              ],
+                      if (notification.isUnread)
+                        Container(
+                            height: 8,
+                            width: 8,
+                            decoration: BoxDecoration(
+                                color: Colors.blue, shape: BoxShape.circle)),
+                      if (notification.hasLandingMessage) Icon(Icons.attachment_sharp,)
+                    ],
+                  ),
+                  Padding(padding: const EdgeInsets.symmetric(vertical: 6)),
+                  Text(notification.body),
+                ],
+              ),
             ),
-          ),
-          PopupMenuButton(
-              itemBuilder: (context) {
-                return makePopupMenu(context);
-              },
-              onSelected: performPopupMenuAction),
-        ],
+            PopupMenuButton(
+                itemBuilder: (context) {
+                  return makePopupMenu(context);
+                },
+                onSelected: performPopupMenuAction),
+          ],
+        ),
       ),
     );
   }

--- a/example/lib/batch_store/ui/inbox/inbox_tab.dart
+++ b/example/lib/batch_store/ui/inbox/inbox_tab.dart
@@ -72,6 +72,10 @@ class _InboxTabState extends State<InboxTab> {
     _fastRefresh();
   }
 
+  void _displayLandingMessage(BatchInboxNotificationContent notification) {
+    fetcher?.displayNotificationLandingMessage(notification);
+  }
+
   @override
   void dispose() {
     super.dispose();
@@ -99,7 +103,10 @@ class _InboxTabState extends State<InboxTab> {
                       },
                       onDelete: () {
                         _delete(notification);
-                      });
+                      },
+                      onDisplayLandingMessage: () {
+                        _displayLandingMessage(notification);
+                    });
                 },
               ),
               onRefresh: _refresh),

--- a/example/lib/batch_store/ui/shop/shop_tab.dart
+++ b/example/lib/batch_store/ui/shop/shop_tab.dart
@@ -21,7 +21,7 @@ class ShopTab extends StatelessWidget {
     List<Article> allArticles = ArticlesFakeDatasource.allArticles;
     return GridView.builder(
         gridDelegate:
-            SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 200),
+            SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 300),
         itemCount: allArticles.length,
         itemBuilder: (BuildContext context, int index) {
           final Article article = allArticles[index];

--- a/example/lib/plugin_test_menu.dart
+++ b/example/lib/plugin_test_menu.dart
@@ -91,6 +91,8 @@ class _PluginTestMenuState extends State<PluginTestMenu> {
     BatchUserDataEditor editor = BatchUser.instance.newEditor();
     editor
         .setIdentifier("test_user")
+        .setEmail("john.doe@batch.com")
+        .setEmailMarketingSubscriptionState(BatchEmailSubscriptionState.subscribed)
         .setBooleanAttribute("bootl", true)
         .setStringAttribute("string", "bar")
         .setDateTimeAttribute("date", DateTime.now())

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.4.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,9 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   batch_flutter:
     dependency: "direct main"
     description:
@@ -19,51 +20,58 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,153 +87,150 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   nested:
     dependency: transitive
     description:
       name: nested
-      url: "https://pub.dartlang.org"
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.1"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.1"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.2.1"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.3"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: f4f88d4a900933e7267e2b353594774fc0d07fb072b47eedcd5b54e1ea3269f8
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.2.4"
+    version: "2.1.7"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      url: "https://pub.dartlang.org"
+      sha256: "59471e0a4595e264625d3496af567ac85bdae1148ec985aff1e0555786f53ecf"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      url: "https://pub.dartlang.org"
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.13"
+    version: "2.2.2"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      url: "https://pub.dartlang.org"
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.11"
-  shared_preferences_ios:
+    version: "2.2.1"
+  shared_preferences_foundation:
     dependency: transitive
     description:
-      name: shared_preferences_ios
-      url: "https://pub.dartlang.org"
+      name: shared_preferences_foundation
+      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.10"
+    version: "2.3.4"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.3"
+    version: "2.3.2"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.3.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      url: "https://pub.dartlang.org"
+      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.2.2"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -235,65 +240,82 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: b0f37db61ba2f2e9b7a78a1caece0052564d1bc70668156cf3a29d676fe4e574
+      url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "5.1.1"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.0+1"
+    version: "1.0.3"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=2.8.0"
+  dart: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0"

--- a/ios/Classes/BatchFlutterPlugin.swift
+++ b/ios/Classes/BatchFlutterPlugin.swift
@@ -4,10 +4,10 @@ import Batch
 
 fileprivate struct Consts {
     static let BridgeVersionEnvironmentVar = "BATCH_BRIDGE_VERSION"
-    static let BridgeVersion = "Bridge/1.2"
+    static let BridgeVersion = "Bridge/1.3"
     
     static let PluginVersionEnvironmentVar = "BATCH_PLUGIN_VERSION"
-    static let PluginVersion = "Flutter/1.3.0"
+    static let PluginVersion = "Flutter/1.4.0"
 }
 
 /// Batch's Flutter Plugin main class.

--- a/ios/Classes/BatchPluginConfiguration.swift
+++ b/ios/Classes/BatchPluginConfiguration.swift
@@ -3,13 +3,12 @@ import Batch
 
 fileprivate struct PlistKeys {
     static let APIKey = "BatchFlutterAPIKey"
-    static let canUseIDFA = "BatchFlutterCanUseIDFA"
     static let canUseAdvancedDeviceInformation = "BatchFlutterCanUseAdvancedDeviceInformation"
     static let initialDnDState = "BatchFlutterDoNotDisturbInitialState"
 }
 
 /**
- Manages Batch's Flutter plugin confgugration. Do not instantiate this directly, use BatchFlutterPlugin to get an instance: your changes will otherwise be ignored.
+ Manages Batch's Flutter plugin configuration. Do not instantiate this directly, use BatchFlutterPlugin to get an instance: your changes will otherwise be ignored.
  
  This class' default values are initialized using your Info.plist settings, if any.
  */
@@ -17,7 +16,10 @@ fileprivate struct PlistKeys {
 public class BatchPluginConfiguration: NSObject {
     
     public var APIKey: String? = nil
+
+    @available(*, deprecated, message: "As Batch has removed support for automatic IDFA collection, this property does nothing.")
     public var canUseIDFA: Bool = false
+
     public var canUseAdvancedDeviceInformation: Bool = true
     public var initialDoNotDisturbState: Bool = false
     
@@ -38,7 +40,6 @@ public class BatchPluginConfiguration: NSObject {
         didReadInfoPlist = true
         
         APIKey = PlistReader.readString(key: PlistKeys.APIKey)
-        canUseIDFA = PlistReader.readBoolean(key: PlistKeys.canUseIDFA, fallbackValue: canUseIDFA)
         canUseAdvancedDeviceInformation = PlistReader.readBoolean(key: PlistKeys.canUseAdvancedDeviceInformation, fallbackValue: canUseAdvancedDeviceInformation)
         initialDoNotDisturbState = PlistReader.readBoolean(key: PlistKeys.initialDnDState, fallbackValue: initialDoNotDisturbState)
     }
@@ -47,7 +48,6 @@ public class BatchPluginConfiguration: NSObject {
     internal func apply() -> Bool {
         if let APIKey = APIKey, APIKey.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 {
             actualAPIKey = APIKey
-            Batch.setUseIDFA(canUseIDFA)
             Batch.setUseAdvancedDeviceInformation(canUseAdvancedDeviceInformation)
             BatchMessaging.doNotDisturb = initialDoNotDisturbState
             return true

--- a/ios/Classes/Interop/Action.swift
+++ b/ios/Classes/Interop/Action.swift
@@ -31,7 +31,8 @@ enum Action: String {
     case inbox_markAsRead = "inbox.markAsRead"
     case inbox_markAllAsRead = "inbox.markAllAsRead"
     case inbox_markAsDeleted = "inbox.markAsDeleted"
-    
+    case inbox_displayLandingMessage = "inbox.displayLandingMessage"
+
     case messaging_setDoNotDisturbEnabled = "messaging.setDoNotDisturbEnabled"
     case messaging_showPendingMessage = "messaging.showPendingMessage"
     

--- a/ios/Classes/Interop/Bridge+UserData.swift
+++ b/ios/Classes/Interop/Bridge+UserData.swift
@@ -10,6 +10,7 @@ extension Bridge {
         case setIdentifier = "SET_IDENTIFIER"
         case setEmail = "SET_EMAIL"
         case setEmailMarketingSubscription = "SET_EMAIL_MARKETING_SUBSCRIPTION"
+        case setAttributionId = "SET_ATTRIBUTION_ID"
         case setAttribute = "SET_ATTRIBUTE"
         case removeAttribute = "REMOVE_ATTRIBUTE"
         case clearAttributes = "CLEAR_ATTRIBUTES"
@@ -81,6 +82,17 @@ extension Bridge {
                         userDataEditor.setEmailMarketingSubscriptionState(.unsubscribed)
                     } else {
                         throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
+                    }
+                    break;
+                case .setIdentifier:
+                    let rawValue = operationDescription["value"]
+                    if rawValue == nil || rawValue is NSNull {
+                        userDataEditor.setAttributionIdentifier(nil)
+                    } else {
+                        guard let value = rawValue as? String else {
+                            throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
+                        }
+                        userDataEditor.setAttributionIdentifier(value)
                     }
                     break;
                 case .setLanguage:

--- a/ios/Classes/Interop/Bridge+UserData.swift
+++ b/ios/Classes/Interop/Bridge+UserData.swift
@@ -8,6 +8,8 @@ extension Bridge {
         case setLanguage = "SET_LANGUAGE"
         case setRegion = "SET_REGION"
         case setIdentifier = "SET_IDENTIFIER"
+        case setEmail = "SET_EMAIL"
+        case setEmailMarketingSubscription = "SET_EMAIL_MARKETING_SUBSCRIPTION"
         case setAttribute = "SET_ATTRIBUTE"
         case removeAttribute = "REMOVE_ATTRIBUTE"
         case clearAttributes = "CLEAR_ATTRIBUTES"
@@ -54,6 +56,31 @@ extension Bridge {
                             throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
                         }
                         userDataEditor.setIdentifier(value)
+                    }
+                    break;
+                case .setEmail:
+                    let rawValue = operationDescription["value"]
+                    if rawValue == nil || rawValue is NSNull {
+                        try? userDataEditor.setEmail(nil)
+                    } else {
+                        guard let value = rawValue as? String else {
+                            throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
+                        }
+                        try? userDataEditor.setEmail(value)
+                    }
+                    break;
+                case .setEmailMarketingSubscription:
+                    let rawValue = operationDescription["value"]
+                    guard let value = rawValue as? String else {
+                        throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
+                    }
+                    print(value)
+                    if (value == "subscribed") {
+                        userDataEditor.setEmailMarketingSubscriptionState(.subscribed)
+                    } else if (value == "unsubscribed") {
+                        userDataEditor.setEmailMarketingSubscriptionState(.unsubscribed)
+                    } else {
+                        throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
                     }
                     break;
                 case .setLanguage:

--- a/ios/Classes/Interop/Bridge+UserData.swift
+++ b/ios/Classes/Interop/Bridge+UserData.swift
@@ -75,7 +75,6 @@ extension Bridge {
                     guard let value = rawValue as? String else {
                         throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
                     }
-                    print(value)
                     if (value == "subscribed") {
                         userDataEditor.setEmailMarketingSubscriptionState(.subscribed)
                     } else if (value == "unsubscribed") {
@@ -84,7 +83,7 @@ extension Bridge {
                         throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
                     }
                     break;
-                case .setIdentifier:
+                case .setAttributionId:
                     let rawValue = operationDescription["value"]
                     if rawValue == nil || rawValue is NSNull {
                         userDataEditor.setAttributionIdentifier(nil)

--- a/ios/Classes/Interop/Bridge.swift
+++ b/ios/Classes/Interop/Bridge.swift
@@ -94,7 +94,8 @@ struct Bridge {
                      .inbox_getFetchedNotifications,
                      .inbox_markAsRead,
                      .inbox_markAllAsRead,
-                     .inbox_markAsDeleted:
+                     .inbox_markAsDeleted,
+                     .inbox_displayLandingMessage:
                     return try inboxBridge.doAction(action, parameters: parameters)
                 
                 case .echo:

--- a/ios/batch_flutter.podspec
+++ b/ios/batch_flutter.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Batch', '~> 1.19.2'
+  s.dependency 'Batch', '~> 1.20.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/batch_flutter.podspec
+++ b/ios/batch_flutter.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Batch', '~> 1.20.0'
+  s.dependency 'Batch', '~> 1.21.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/batch_flutter.podspec
+++ b/ios/batch_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'batch_flutter'
-  s.version          = '0.0.5'
+  s.version          = '0.0.6'
   s.summary          = 'Batch.com Flutter Plugin'
   s.homepage         = 'https://batch.com'
   s.license          = { :type => 'MIT', :file => '../LICENSE' }
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.ios.deployment_target  = '10.0'
+  s.ios.deployment_target  = '12.0'
   s.swift_version = '5.0'
   s.static_framework = true
 

--- a/lib/batch_inbox.dart
+++ b/lib/batch_inbox.dart
@@ -134,6 +134,13 @@ abstract class BatchInboxFetcher {
   Future<void> markNotificationAsDeleted(
       BatchInboxNotificationContent notification);
 
+  /// Display the landing message attached to a BatchInboxNotificationContent.
+  /// Do nothing if no message is attached.
+  ///
+  /// Note that this method will work even if Batch is in do not disturb mode.
+  Future<void> displayNotificationLandingMessage(
+      BatchInboxNotificationContent notification);
+
   /// Call this once you're finished with this fetcher to release the native
   /// object and free all memory. Usually, this should be called
   /// in your State's dispose.
@@ -155,7 +162,7 @@ class BatchInboxNotificationContent {
   /// Internal constructor.
   /// <nodoc>
   BatchInboxNotificationContent(this.id, this.title, this.body, this.isUnread,
-      this.date, this.source, this.payload);
+      this.date, this.source, this.payload, this.hasLandingMessage);
 
   /// The unique notification identifier. Do not make assumptions about its format: it can change at any time.
   final String id;
@@ -187,6 +194,9 @@ class BatchInboxNotificationContent {
   ///
   /// Keys in "com.batch" are private and should not be relied on.
   final Map<String, String> payload;
+
+  /// Whether the notification content has a landing message attached.
+  final bool hasLandingMessage;
 }
 
 /// Describes a fetch operation result

--- a/lib/batch_user.dart
+++ b/lib/batch_user.dart
@@ -197,7 +197,7 @@ abstract class BatchUserDataEditor {
   /// Since automatic collection of the advertising ID has been removed
   /// from native SDKs, you can now collect it from your side and pass it to Batch.
   /// Must be a valid IDFA or GAID. Null to erase.
-  BatchUserDataEditor setAttributionIdentifier(String? email);
+  BatchUserDataEditor setAttributionIdentifier(String? attributionId);
 
   /// Set a string attribute for a key.
   ///

--- a/lib/batch_user.dart
+++ b/lib/batch_user.dart
@@ -154,6 +154,10 @@ class BatchUser {
   }
 }
 
+/// Email subscription state
+enum BatchEmailSubscriptionState { subscribed, unsubscribed }
+
+
 /// Batch's user data editor.
 /// This object is used to transactionally edit user data. Calls can be chained
 /// in a builder-like fashion.
@@ -175,6 +179,18 @@ abstract class BatchUserDataEditor {
   /// When pushing using an identifier, all installations with that identifier will get the Push,
   /// which can cause some privacy issues if done wrong.
   BatchUserDataEditor setIdentifier(String? identifier);
+
+  /// Set the user email address.
+  ///
+  /// This requires to have a custom user ID registered
+  /// or to call the `setIdentifier` method on the editor instance beforehand.
+  /// Null to erase. Addresses must be valid.
+  BatchUserDataEditor setEmail(String? email);
+
+  /// Set the user email marketing subscription state
+  ///
+  /// Use enum BatchEmailSubscriptionState.subscribed or BatchEmailSubscriptionState.unsubscribed
+  BatchUserDataEditor setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state);
 
   /// Set a string attribute for a key.
   ///

--- a/lib/batch_user.dart
+++ b/lib/batch_user.dart
@@ -192,11 +192,18 @@ abstract class BatchUserDataEditor {
   /// Use enum BatchEmailSubscriptionState.subscribed or BatchEmailSubscriptionState.unsubscribed
   BatchUserDataEditor setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state);
 
+  /// Set the user attribution identifier
+  ///
+  /// Since automatic collection of the advertising ID has been removed
+  /// from native SDKs, you can now collect it from your side and pass it to Batch.
+  /// Must be a valid IDFA or GAID. Null to erase.
+  BatchUserDataEditor setAttributionIdentifier(String? email);
+
   /// Set a string attribute for a key.
   ///
   /// Attribute's key cannot be empty. It should be made of letters, numbers or underscores (\[a-z0-9_\])
   /// and can't be longer than 30 characters.
-  /// String attribut values are non-empty strings and can't be longer than 64 characters.
+  /// String attribute values are non-empty strings and can't be longer than 64 characters.
   ///
   /// Any attribute with an invalid key or value will be ignored.
   BatchUserDataEditor setStringAttribute(String key, String value);

--- a/lib/src/inbox_fetcher.dart
+++ b/lib/src/inbox_fetcher.dart
@@ -88,6 +88,17 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
     await _channel.invokeMethod("inbox.markAsDeleted", parameters);
   }
 
+
+  @override
+  Future<void> displayNotificationLandingMessage(
+      BatchInboxNotificationContent notification) async {
+    _throwIfDisposed();
+
+    Map<String, dynamic> parameters = _makeBaseBridgeParameters();
+    parameters["notifID"] = notification.id;
+    await _channel.invokeMethod("inbox.displayLandingMessage", parameters);
+  }
+
   @override
   void dispose() {
     _disposed = true;
@@ -138,6 +149,7 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
           DateTime.fromMillisecondsSinceEpoch(rawNotification["date"] as int)
               .toUtc();
       int rawSource = rawNotification["source"] as int;
+      bool hasLandingMessage = rawNotification["hasLandingMessage"] as bool;
       BatchInboxNotificationSource source =
           BatchInboxNotificationSource.unknown;
       switch (rawSource) {
@@ -154,7 +166,7 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
       Map<String, String> payload = (rawNotification["payload"] as Map).cast();
 
       notifications.add(BatchInboxNotificationContent(
-          id, title, body, isUnread, date, source, payload));
+          id, title, body, isUnread, date, source, payload, hasLandingMessage));
     });
 
     return notifications;

--- a/lib/src/user_data_editor.dart
+++ b/lib/src/user_data_editor.dart
@@ -13,6 +13,7 @@ enum UserDataOperationKind {
   setIdentifier,
   setEmail,
   setEmailMarketingSubscriptionState,
+  setAttributionId,
   setAttribute,
   removeAttribute,
   clearAttributes,
@@ -35,6 +36,8 @@ extension UserDataOperationKindBridge on UserDataOperationKind {
         return "SET_EMAIL";
       case UserDataOperationKind.setEmailMarketingSubscriptionState:
         return "SET_EMAIL_MARKETING_SUBSCRIPTION";
+      case UserDataOperationKind.setAttributionId:
+        return "SET_ATTRIBUTION_ID";
       case UserDataOperationKind.setAttribute:
         return "SET_ATTRIBUTE";
       case UserDataOperationKind.removeAttribute:
@@ -151,6 +154,20 @@ class BatchUserDataEditorImpl implements BatchUserDataEditor {
   BatchUserDataEditor setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state) {
     _enqueueOperation(UserDataOperationKind.setEmailMarketingSubscriptionState, {
       "value": state.name,
+    });
+    return this;
+  }
+
+  @override
+  BatchUserDataEditor setAttributionIdentifier(String? identifier) {
+    if (identifier != null && identifier.length == 0) {
+      BatchLogger.public(
+          "BatchUserDataEditor - Attribution identifier cannot be empty. If " +
+              "you meant to un-set the attribution identifier, please use null.");
+      return this;
+    }
+    _enqueueOperation(UserDataOperationKind.setAttributionId, {
+      "value": identifier,
     });
     return this;
   }

--- a/lib/src/user_data_editor.dart
+++ b/lib/src/user_data_editor.dart
@@ -11,6 +11,8 @@ enum UserDataOperationKind {
   setLanguage,
   setRegion,
   setIdentifier,
+  setEmail,
+  setEmailMarketingSubscriptionState,
   setAttribute,
   removeAttribute,
   clearAttributes,
@@ -29,6 +31,10 @@ extension UserDataOperationKindBridge on UserDataOperationKind {
         return "SET_REGION";
       case UserDataOperationKind.setIdentifier:
         return "SET_IDENTIFIER";
+      case UserDataOperationKind.setEmail:
+        return "SET_EMAIL";
+      case UserDataOperationKind.setEmailMarketingSubscriptionState:
+        return "SET_EMAIL_MARKETING_SUBSCRIPTION";
       case UserDataOperationKind.setAttribute:
         return "SET_ATTRIBUTE";
       case UserDataOperationKind.removeAttribute:
@@ -123,6 +129,29 @@ class BatchUserDataEditorImpl implements BatchUserDataEditor {
       "value": identifier,
     });
 
+    return this;
+  }
+
+  @override
+  BatchUserDataEditor setEmail(String? address) {
+    if (address != null && address.length == 0) {
+      BatchLogger.public(
+          "BatchUserDataEditor - Email cannot be empty. If " +
+              "you meant to un-set the email, please use null.");
+      return this;
+    }
+
+    _enqueueOperation(UserDataOperationKind.setEmail, {
+      "value": address,
+    });
+    return this;
+  }
+
+  @override
+  BatchUserDataEditor setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state) {
+    _enqueueOperation(UserDataOperationKind.setEmailMarketingSubscriptionState, {
+      "value": state.name,
+    });
     return this;
   }
 

--- a/lib/src/user_data_editor.dart
+++ b/lib/src/user_data_editor.dart
@@ -159,15 +159,15 @@ class BatchUserDataEditorImpl implements BatchUserDataEditor {
   }
 
   @override
-  BatchUserDataEditor setAttributionIdentifier(String? identifier) {
-    if (identifier != null && identifier.length == 0) {
+  BatchUserDataEditor setAttributionIdentifier(String? attributionId) {
+    if (attributionId != null && attributionId.length == 0) {
       BatchLogger.public(
           "BatchUserDataEditor - Attribution identifier cannot be empty. If " +
               "you meant to un-set the attribution identifier, please use null.");
       return this;
     }
     _enqueueOperation(UserDataOperationKind.setAttributionId, {
-      "value": identifier,
+      "value": attributionId,
     });
     return this;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,48 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -57,30 +63,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -90,51 +100,66 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.3.0
 homepage: https://batch.com
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
   flutter: ">=2.0.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: batch_flutter
 description: Batch SDK Flutter Plugin allows you to build meaningful communication experiences in your app through highly personalized push notifications and In-App messages.
-version: 1.3.0
+version: 1.4.0
 homepage: https://batch.com
 
 environment:


### PR DESCRIPTION
**Plugin**

* Dart 2.15+ is now required.
* Updated Batch to 1.21.0. 
* Batch requires iOS 12.0 or higher.
* Batch now compiles with and targets SDK 34 (Android 14).

**User**

* Removed automatic collection of the advertising id:
  * Android's Methods `setCanUseAdvertisingID` and `canUseAdvertisingID` from `BatchPluginConfiguration` are now deprecated and do nothing.
  * Android's manifest configuration `com.batch.flutter.use_gaid` has been removed.
  * iOS's property `canUseIDFA` from `BatchPluginConfiguration` is now deprecated and does nothing.
  * iOS's Info.plist property `BatchFlutterCanUseIDFA` has been removed.
  * You need to collect it from your side and pass it to Batch via the added `setAttributionIdentifier(String? id)` method. Batch will persist it across starts.
* Added `setEmail(String? email)` method to `BatchUserDataEditor`. This requires to have a user identifier registered or to call the `setIdentifier` method on the editor instance beforehand.
* Added `setEmailMarketingSubscriptionState(BatchEmailSubscriptionState state)` method to `BatchUserDataEditor`. 

**Inbox**

* Added `hasLandingMessage` property to `BatchInboxNotificationContent`.
* Added `displayNotificationLandingMessage(BatchInboxNotificationContent notification)` method to `BatchInboxFetcher`.  