### PR TITLE
Release 3.1.0

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,0 +1,19 @@
+name: Code Formatting
+
+on:
+  push:
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Run format check
+        run: make format-check

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -8,12 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Dart
-        uses: dart-lang/setup-dart@v1
+        uses: actions/checkout@v6
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
         with:
-          sdk: stable
-
-      - name: Run format check
-        run: make format-check
+          channel: stable
+      - run: flutter pub get
+      - run: make format-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added `setTopicPreferences(List<String>? topics)` to `BatchProfileAttributeEditor` class to set or reset the profile topic preferences.
 - Added `addToTopicPreferences(List<String> topics)` to `BatchProfileAttributeEditor` class to add topics to the profile topic preferences.
 - Added `removeFromTopicPreferences(List<String> topics)` to `BatchProfileAttributeEditor` class to remove topics from the profile topic preferences.
+- Profile string attributes now support up to 300 characters for the Customer Engagement Platform (CEP). The limit for the Mobile Engagement Platform (MEP) remains 64 characters. Attributes set via `BatchProfileAttributeEditor.setStringAttribute()` longer than 64 characters will only be applied to the CEP.
+- Event string attributes now support up to 300 characters for the Customer Engagement Platform (CEP). The limit for the Mobile Engagement Platform (MEP) remains 200 characters. Attributes set via `BatchEventAttributes.putString()` longer than 200 characters will only be applied to the CEP.
 
 **Push**
 - Added `requestNotificationAuthorizationAsync()`to request notification authorization and return a promise that resolve with the authorization result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UPCOMING
+
+**Push**
+- Added `requestNotificationAuthorizationAsync()`to request notification authorization and return a promise that resolve with the authorization result.
+
 ## 3.0.0
 
 **Plugin**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UPCOMING
+## 3.1.0
 
 **Plugin**
 - Updated Batch to 3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## UPCOMING
 
+**Plugin**
+- Updated Batch to 3.3
+
+**Profile**
+- Added `setTopicPreferences(List<String>? topics)` to `BatchProfileAttributeEditor` class to set or reset the profile topic preferences.
+- Added `addToTopicPreferences(List<String> topics)` to `BatchProfileAttributeEditor` class to add topics to the profile topic preferences.
+- Added `removeFromTopicPreferences(List<String> topics)` to `BatchProfileAttributeEditor` class to remove topics from the profile topic preferences.
+
 **Push**
 - Added `requestNotificationAuthorizationAsync()`to request notification authorization and return a promise that resolve with the authorization result.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs doc doc-ios doc-android build-ios-doc setup-build-ios flutter-setup
+.PHONY: docs doc doc-ios doc-android build-ios-doc setup-build-ios flutter-setup format format-check
 
 # Common Flutter setup - run once to avoid redundancy
 flutter-setup:
@@ -82,3 +82,9 @@ doc-ios: build-ios-doc
 doc-android:
 	rm -rf api_docs/flutter-android-api-reference
 	cd example/android && ./gradlew :batch_flutter:generateJavadocRelease
+
+format:
+	dart format lib
+
+format-check:
+	dart format lib -o none --set-exit-if-changed

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+formatter:
+  page_width: 100
+  trailing_commas: preserve

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
     }
 
     dependencies {
-        api 'com.batch.android:batch-sdk:3.1.+'
+        api 'com.batch.android:batch-sdk:3.3.+'
         //noinspection GradleDynamicVersion
         implementation 'androidx.appcompat:appcompat:1.2.0'
 

--- a/android/src/main/java/com/batch/batch_flutter/BatchFlutterPlugin.java
+++ b/android/src/main/java/com/batch/batch_flutter/BatchFlutterPlugin.java
@@ -37,7 +37,7 @@ public class BatchFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
 
     private static final String PLUGIN_VERSION_SYSTEM_PROPERTY = "batch.plugin.version";
 
-    private static final String PLUGIN_VERSION = "Flutter/3.0.0";
+    private static final String PLUGIN_VERSION = "Flutter/3.1.0";
 
     private final static BatchPluginConfiguration configuration = new BatchPluginConfiguration();
 

--- a/android/src/main/java/com/batch/batch_flutter/interop/Action.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/Action.java
@@ -16,6 +16,7 @@ enum Action
 
     PUSH_GET_LAST_KNOWN_TOKEN("push.getLastKnownPushToken"),
     PUSH_REQUEST_PERMISSION("push.requestPermission"),
+    PUSH_REQUEST_PERMISSION_ASYNC("push.requestPermissionAsync"),
     PUSH_IOS_REQUEST_PROVISIONAL_PERMISSION("push.iOS.requestProvisionalPermission"),
     PUSH_IOS_REFRESH_TOKEN("push.iOS.refreshToken"),
     PUSH_IOS_SET_SHOW_FOREGROUND("push.iOS.setShowForegroundNotifications"),

--- a/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
@@ -18,6 +18,7 @@ import com.batch.android.BatchEmailSubscriptionState;
 import com.batch.android.BatchEventAttributes;
 import com.batch.android.BatchMessage;
 import com.batch.android.BatchOptOutResultListener;
+import com.batch.android.BatchPermissionListener;
 import com.batch.android.BatchProfileAttributeEditor;
 import com.batch.android.BatchPushRegistration;
 import com.batch.android.BatchSMSSubscriptionState;
@@ -111,6 +112,8 @@ public class BatchBridge {
             case PUSH_REQUEST_PERMISSION:
                 Batch.Push.requestNotificationPermission(activity);
                 return Promise.resolved(null);
+            case PUSH_REQUEST_PERMISSION_ASYNC:
+                return requestNotificationPermission(activity);
             case PUSH_IOS_REFRESH_TOKEN:
             case PUSH_IOS_REQUEST_PROVISIONAL_PERMISSION:
             case PUSH_CLEAR_BADGE:
@@ -223,6 +226,17 @@ public class BatchBridge {
 
     private static Boolean shouldShowNotifications(Context context) {
         return Batch.Push.shouldShowNotifications(context);
+    }
+
+    private static Promise<Object> requestNotificationPermission(Activity activity) {
+        return new Promise<>(promise ->
+                Batch.Push.requestNotificationPermission(activity, new BatchPermissionListener() {
+                    @Override
+                    public void onPermissionRequested(boolean granted) {
+                        promise.resolve(granted);
+                    }
+                })
+        );
     }
 
 //region Profile

--- a/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
@@ -45,7 +45,7 @@ import java.util.Set;
 public class BatchBridge {
     private static final String BRIDGE_VERSION_ENVIRONEMENT_VAR = "batch.bridge.version";
 
-    private static final String BRIDGE_VERSION = "Bridge/1.0";
+    private static final String BRIDGE_VERSION = "Bridge/3.1";
 
     private static final InboxBridge inboxBridge = new InboxBridge();
 

--- a/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
+++ b/android/src/main/java/com/batch/batch_flutter/interop/BatchBridge.java
@@ -331,6 +331,24 @@ public class BatchBridge {
                         }
                         break;
                     }
+                    case "SET_TOPIC_PREFERENCES": {
+                        Object value = operationDescription.get("value");
+                        if (value == null) {
+                            editor.setTopicPreferences(null);
+                            break;
+                        }
+
+                        editor.setTopicPreferences(new ArrayList<>(getTypedParameter(operationDescription, "value", ArrayList.class)));
+                        break;
+                    }
+                    case "ADD_TO_TOPIC_PREFERENCES": {
+                        editor.addToTopicPreferences(new ArrayList<>(getTypedParameter(operationDescription, "value", ArrayList.class)));
+                        break;
+                    }
+                    case "REMOVE_FROM_TOPIC_PREFERENCES": {
+                        editor.removeFromTopicPreferences(new ArrayList<>(getTypedParameter(operationDescription, "value", ArrayList.class)));
+                        break;
+                    }
                     case "SET_ATTRIBUTE": {
                         String key = getTypedParameter(operationDescription, "key", String.class);
                         String type = getTypedParameter(operationDescription, "type", String.class);

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Batch (3.1.0)
+  - Batch (3.3.0)
   - batch_flutter (3.0.0):
-    - Batch (~> 3.1.0)
+    - Batch (~> 3.3.0)
     - Flutter
   - batch_flutter/Tests (3.0.0):
-    - Batch (~> 3.1.0)
+    - Batch (~> 3.3.0)
     - Flutter
   - BatchExtension (4.0.0)
   - Flutter (1.0.0)
@@ -33,12 +33,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  Batch: 47c1df1f301078fc01b9f9531faeed8f18a9bac0
-  batch_flutter: 8ee966aebb5c381bf990f60abe7b6aabb1cc51f2
+  Batch: eadfdd781276a94730fc456abb994c259b8dc2ac
+  batch_flutter: 52cc6d3d6fd8deb163c43c3ebb6768683e3182f5
   BatchExtension: ee10c31cc737d66a9c339a1e70e7c787b5988676
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
 
 PODFILE CHECKSUM: 41d7fb270f6b26ab3bf4c5441ef0bb80b305699a
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Batch (3.3.0)
-  - batch_flutter (3.0.0):
+  - batch_flutter (3.1.0):
     - Batch (~> 3.3.0)
     - Flutter
-  - batch_flutter/Tests (3.0.0):
+  - batch_flutter/Tests (3.1.0):
     - Batch (~> 3.3.0)
     - Flutter
   - BatchExtension (4.0.0)
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Batch: eadfdd781276a94730fc456abb994c259b8dc2ac
-  batch_flutter: 52cc6d3d6fd8deb163c43c3ebb6768683e3182f5
+  batch_flutter: e8972ee844d7b3715da0608de1da84c9a9dcd719
   BatchExtension: ee10c31cc737d66a9c339a1e70e7c787b5988676
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78

--- a/example/lib/plugin_test_menu.dart
+++ b/example/lib/plugin_test_menu.dart
@@ -173,6 +173,19 @@ class _PluginTestMenuState extends State<PluginTestMenu> {
     print(notifs.notifications);
   }
 
+  Future<void> requestNotificationAuthorizationAsync() async {
+    final granted =
+        await BatchPush.instance.requestNotificationAuthorizationAsync();
+
+    if (!mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text("Notification auth async result: $granted"),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -194,6 +207,10 @@ class _PluginTestMenuState extends State<PluginTestMenu> {
               child: Text("Request notif. auth."),
               onPressed: () =>
                   BatchPush.instance.requestNotificationAuthorization(),
+            ),
+            ElevatedButton(
+              child: Text("Request notif. auth. async"),
+              onPressed: () => requestNotificationAuthorizationAsync(),
             ),
             Row(
               children: <Widget>[

--- a/example/lib/plugin_test_menu.dart
+++ b/example/lib/plugin_test_menu.dart
@@ -142,6 +142,9 @@ class _PluginTestMenuState extends State<PluginTestMenu> {
         .removeFromArray("push_optin", "handball")
         .setLanguage("pt")
         .setRegion("BR")
+        .setTopicPreferences(["topic3", "topic1"])
+        .addToTopicPreferences(["topic2"])
+        .removeFromTopicPreferences(["topic3"])
         .save();
   }
 
@@ -158,6 +161,7 @@ class _PluginTestMenuState extends State<PluginTestMenu> {
         .setPhoneNumber(null)
         .setLanguage(null)
         .setRegion(null)
+        .setTopicPreferences(null)
         .save();
     BatchUser.instance.clearInstallationData();
   }

--- a/ios/batch_flutter.podspec
+++ b/ios/batch_flutter.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'batch_flutter/Sources/batch_flutter/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Batch', '~> 3.1.0'
+  s.dependency 'Batch', '~> 3.3.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/batch_flutter.podspec
+++ b/ios/batch_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'batch_flutter'
-  s.version          = '3.0.0'
+  s.version          = '3.1.0'
   s.summary          = 'Batch.com Flutter Plugin'
   s.homepage         = 'https://batch.com'
   s.license          = { :type => 'MIT', :file => '../LICENSE' }

--- a/ios/batch_flutter/Package.resolved
+++ b/ios/batch_flutter/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/BatchLabs/Batch-iOS-SDK",
       "state" : {
-        "revision" : "5cdc9374f82414dcce8dbaab02ab6277e16c0d12",
-        "version" : "3.1.0"
+        "revision" : "38d18980984122deac4a777f365a5b0009508cbc",
+        "version" : "3.3.0"
       }
     }
   ],

--- a/ios/batch_flutter/Package.swift
+++ b/ios/batch_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "batch-flutter", targets: ["batch_flutter"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK", from: "3.1.0"),
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK", from: "3.3.0"),
     ],
     targets: [
         .target(

--- a/ios/batch_flutter/Sources/batch_flutter/BatchFlutterPlugin.swift
+++ b/ios/batch_flutter/Sources/batch_flutter/BatchFlutterPlugin.swift
@@ -4,7 +4,7 @@ import Batch
 
 fileprivate struct Consts {
 	static let BridgeVersionEnvironmentVar = "BATCH_BRIDGE_VERSION"
-	static let BridgeVersion = "Bridge/3.0"
+	static let BridgeVersion = "Bridge/3.1"
 	
 	static let PluginVersionEnvironmentVar = "BATCH_PLUGIN_VERSION"
 	static let PluginVersion = "Flutter/3.0.0"

--- a/ios/batch_flutter/Sources/batch_flutter/Interop/Action.swift
+++ b/ios/batch_flutter/Sources/batch_flutter/Interop/Action.swift
@@ -7,6 +7,7 @@ enum Action: String {
     
     case push_getLastKnownPushToken = "push.getLastKnownPushToken"
     case push_RequestPermission = "push.requestPermission"
+    case push_RequestPermissionAsync = "push.requestPermissionAsync"
     case push_iOSRequestProvisionalPermission = "push.iOS.requestProvisionalPermission"
     case push_iOSRefreshToken = "push.iOS.refreshToken"
     case push_clearBadge = "push.clearBadge"

--- a/ios/batch_flutter/Sources/batch_flutter/Interop/Bridge+Profile.swift
+++ b/ios/batch_flutter/Sources/batch_flutter/Interop/Bridge+Profile.swift
@@ -11,6 +11,9 @@ extension Bridge {
         case setEmailMarketingSubscription = "SET_EMAIL_MARKETING_SUBSCRIPTION"
         case setPhoneNumber = "SET_PHONE_NUMBER"
         case setSMSMarketingSubscription = "SET_SMS_MARKETING_SUBSCRIPTION"
+        case setTopicPreferences = "SET_TOPIC_PREFERENCES"
+        case addToTopicPreferences = "ADD_TO_TOPIC_PREFERENCES"
+        case removeFromTopicPreferences = "REMOVE_FROM_TOPIC_PREFERENCES"
         case setAttribute = "SET_ATTRIBUTE"
         case removeAttribute = "REMOVE_ATTRIBUTE"
         case addToStringArray = "ADD_TO_ARRAY"
@@ -105,6 +108,29 @@ extension Bridge {
                 } else {
                     throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
                 }
+                break;
+            case .setTopicPreferences:
+                let rawValue = operationDescription["value"]
+                if rawValue == nil || rawValue is NSNull {
+                    try? profileAttributeEditor.setTopicPreferences(nil)
+                } else {
+                    guard let value = rawValue as? [String] else {
+                        throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
+                    }
+                    try? profileAttributeEditor.setTopicPreferences(value)
+                }
+                break;
+            case .addToTopicPreferences:
+                guard let value = operationDescription["value"] as? [String] else {
+                    throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
+                }
+                try? profileAttributeEditor.addToTopicPreferences(value)
+                break;
+            case .removeFromTopicPreferences:
+                guard let value = operationDescription["value"] as? [String] else {
+                    throw BridgeError.makeBadArgumentError(argumentName: rawOperation + ".value")
+                }
+                try? profileAttributeEditor.removeFromTopicPreferences(value)
                 break;
             case .setLanguage:
                 let rawValue = operationDescription["value"]

--- a/ios/batch_flutter/Sources/batch_flutter/Interop/Bridge.swift
+++ b/ios/batch_flutter/Sources/batch_flutter/Interop/Bridge.swift
@@ -35,6 +35,8 @@ struct Bridge {
                 case .push_RequestPermission:
                     BatchPush.requestNotificationAuthorization()
                     return .emptySuccess
+                case .push_RequestPermissionAsync:
+                    return requestNotificationAuthorization()
                 case .push_iOSRequestProvisionalPermission:
                     BatchPush.requestProvisionalNotificationAuthorization()
                     return .emptySuccess
@@ -125,6 +127,19 @@ struct Bridge {
         }
         
         BatchUNUserNotificationCenterDelegate.sharedInstance.showForegroundNotifications = enabled
+    }
+
+    private func requestNotificationAuthorization() -> LightPromise {
+        return LightPromise { resolve, reject in
+            BatchPush.requestNotificationAuthorization { granted, error in
+                if let error {
+                    reject(error)
+                    return
+                }
+
+                resolve(.number(granted as NSNumber))
+            }
+        }
     }
     
     private func setAutomaticDataCollection(parameters: BridgeParameters) throws {

--- a/lib/batch.dart
+++ b/lib/batch.dart
@@ -97,6 +97,7 @@ class Batch {
   ///     });
   /// ```
   void setAutomaticDataCollection(Map<String, bool> dataCollectionConfig) {
-    _channel.invokeMethod('setAutomaticDataCollection', {"dataCollectionConfig": dataCollectionConfig});
+    _channel
+        .invokeMethod('setAutomaticDataCollection', {"dataCollectionConfig": dataCollectionConfig});
   }
 }

--- a/lib/batch_inbox.dart
+++ b/lib/batch_inbox.dart
@@ -14,8 +14,7 @@ class BatchInbox {
   /// Set [limit] to be the maximum number of notifications to fetch, ever.
   /// This allows you to let Batch manage the upper limit itself, so you can
   /// be sure not to use a crazy amount of memory.
-  Future<BatchInboxFetcher> getFetcherForInstallation(
-      {int? maxPageSize, int? limit}) async {
+  Future<BatchInboxFetcher> getFetcherForInstallation({int? maxPageSize, int? limit}) async {
     var fetcher = BatchInboxFetcherInstallationImpl();
     await fetcher.init(maxPageSize: maxPageSize, limit: limit);
     return fetcher;
@@ -42,8 +41,7 @@ class BatchInbox {
       required String authenticationKey,
       int? maxPageSize,
       int? limit}) async {
-    var fetcher = BatchInboxFetcherUserImpl(
-        user: userIdentifier, authKey: authenticationKey);
+    var fetcher = BatchInboxFetcherUserImpl(user: userIdentifier, authKey: authenticationKey);
     await fetcher.init(maxPageSize: maxPageSize, limit: limit);
     return fetcher;
   }
@@ -115,8 +113,7 @@ abstract class BatchInboxFetcher {
   /// Calling [fetchNewNotifications()]/[fetchNextPage()] right away
   /// might cause notifications to come as unread, as the server needs time to
   /// process your request.
-  Future<void> markNotificationAsRead(
-      BatchInboxNotificationContent notification);
+  Future<void> markNotificationAsRead(BatchInboxNotificationContent notification);
 
   /// Marks all notifications as read.
   /// Note: Please refresh your copy of the notifications using [allNotifications]
@@ -131,15 +128,13 @@ abstract class BatchInboxFetcher {
   /// Calling [fetchNewNotifications()]/[fetchNextPage()] right away
   /// might cause notifications to still be present, as the server needs time to
   /// process your request.
-  Future<void> markNotificationAsDeleted(
-      BatchInboxNotificationContent notification);
+  Future<void> markNotificationAsDeleted(BatchInboxNotificationContent notification);
 
   /// Display the landing message attached to a BatchInboxNotificationContent.
   /// Do nothing if no message is attached.
   ///
   /// Note that this method will work even if Batch is in do not disturb mode.
-  Future<void> displayNotificationLandingMessage(
-      BatchInboxNotificationContent notification);
+  Future<void> displayNotificationLandingMessage(BatchInboxNotificationContent notification);
 
   /// Call this once you're finished with this fetcher to release the native
   /// object and free all memory. Usually, this should be called
@@ -161,8 +156,8 @@ enum BatchInboxNotificationSource { unknown, campaign, transactional, trigger }
 class BatchInboxNotificationContent {
   /// Internal constructor.
   /// <nodoc>
-  BatchInboxNotificationContent(this.id, this.title, this.body, this.isUnread,
-      this.date, this.source, this.payload, this.hasLandingMessage);
+  BatchInboxNotificationContent(this.id, this.title, this.body, this.isUnread, this.date,
+      this.source, this.payload, this.hasLandingMessage);
 
   /// The unique notification identifier. Do not make assumptions about its format: it can change at any time.
   final String id;
@@ -201,8 +196,7 @@ class BatchInboxNotificationContent {
 
 /// Describes a fetch operation result
 class BatchInboxFetchResult {
-  BatchInboxFetchResult(
-      {required this.notifications, required this.endReached});
+  BatchInboxFetchResult({required this.notifications, required this.endReached});
 
   /// Fetched notifications.
   final List<BatchInboxNotificationContent> notifications;

--- a/lib/batch_messaging.dart
+++ b/lib/batch_messaging.dart
@@ -3,8 +3,7 @@ import 'package:flutter/services.dart';
 /// Provides messaging related functionality, such as do not disturb.
 /// Do not instanciate this: use the `instance` static property.
 class BatchMessaging {
-  static const MethodChannel _channel =
-      const MethodChannel('batch_flutter.messaging');
+  static const MethodChannel _channel = const MethodChannel('batch_flutter.messaging');
 
   /// Batch Messaging module singleton.
   static BatchMessaging instance = new BatchMessaging();
@@ -24,8 +23,7 @@ class BatchMessaging {
   /// While DnD is disabled by default, the default state can be configured
   /// in your Info.plist/AndroidManifest.xml
   void setDoNotDisturbEnabled(bool enableDoNotDisturb) {
-    _channel.invokeMethod(
-        'messaging.setDoNotDisturbEnabled', {'enabled': enableDoNotDisturb});
+    _channel.invokeMethod('messaging.setDoNotDisturbEnabled', {'enabled': enableDoNotDisturb});
   }
 
   /// Shows the currently enqueued message, if any.

--- a/lib/batch_profile.dart
+++ b/lib/batch_profile.dart
@@ -130,7 +130,7 @@ abstract class BatchProfileAttributeEditor {
   ///
   /// Attribute's key cannot be empty. It should be made of letters, numbers or underscores (\[a-z0-9_\])
   /// and can't be longer than 30 characters.
-  /// String attribute values are non-empty strings and can't be longer than 64 characters.
+  /// String attribute values are non-empty strings and can't be longer than 300 characters.
   ///
   /// Any attribute with an invalid key or value will be ignored.
   BatchProfileAttributeEditor setStringAttribute(String key, String value);
@@ -237,7 +237,7 @@ class BatchEventAttributes {
   /// The attribute key should be a string composed of letters, numbers
   /// or underscores (\[a-z0-9_\]) and can't be longer than 30 characters.
   ///
-  /// The attribute string value can't be empty or longer than 64 characters.
+  /// The attribute string value can't be empty or longer than 300 characters.
   /// For better results, you should trim/lowercase your strings
   /// and use slugs when possible.
   BatchEventAttributes putString(String key, String value) {

--- a/lib/batch_profile.dart
+++ b/lib/batch_profile.dart
@@ -106,6 +106,28 @@ abstract class BatchProfileAttributeEditor {
   /// Note that profile's subscription status is automatically set to unsubscribed when users send a STOP message.
   BatchProfileAttributeEditor setSMSMarketingSubscription(BatchSMSSubscriptionState state);
 
+  /// Set the profile topic preferences.
+  ///
+  /// `null` resets the topic preferences.
+  /// Values cannot contain more than 25 items.
+  /// Individual items should be made of letters, numbers or underscores
+  /// (`[a-z0-9_]`) and can't be longer than 300 characters.
+  BatchProfileAttributeEditor setTopicPreferences(List<String>? topics);
+
+  /// Add topics to the profile topic preferences.
+  ///
+  /// Values cannot contain more than 25 items.
+  /// Individual items should be made of letters, numbers or underscores
+  /// (`[a-z0-9_]`) and can't be longer than 300 characters.
+  BatchProfileAttributeEditor addToTopicPreferences(List<String> topics);
+
+  /// Remove topics from the profile topic preferences.
+  ///
+  /// Values cannot contain more than 25 items.
+  /// Individual items should be made of letters, numbers or underscores
+  /// (`[a-z0-9_]`) and can't be longer than 300 characters.
+  BatchProfileAttributeEditor removeFromTopicPreferences(List<String> topics);
+
   /// Set a string attribute for a key.
   ///
   /// Attribute's key cannot be empty. It should be made of letters, numbers or underscores (\[a-z0-9_\])
@@ -210,9 +232,7 @@ abstract class BatchProfileAttributeEditor {
 /// Keys should be strings composed of letters, numbers or underscores
 /// (\[a-z0-9_\]) and can't be longer than 30 characters.
 class BatchEventAttributes {
-
   Map<String, TypedAttribute> _attributes = new HashMap();
-
 
   /// Add a string attribute for the given key.
   ///

--- a/lib/batch_profile.dart
+++ b/lib/batch_profile.dart
@@ -9,8 +9,7 @@ import 'package:flutter/widgets.dart';
 /// Provides Profile related functionality, such as custom data and events.
 /// Do not instantiate this: use the `instance` static property.
 class BatchProfile {
-  static const MethodChannel _channel =
-  const MethodChannel('batch_flutter.profile');
+  static const MethodChannel _channel = const MethodChannel('batch_flutter.profile');
 
   /// Batch Profile module singleton.
   static BatchProfile instance = new BatchProfile();
@@ -44,8 +43,8 @@ class BatchProfile {
       eventArgs["event_data"] = attributes.internalGetBridgeRepresentation();
     }
     _channel.invokeMethod("profile.track.event", eventArgs).catchError((error) => {
-      BatchLogger.public("Tracking event '"+ name +"' failed with error: " + error.toString())
-    });
+          BatchLogger.public("Tracking event '" + name + "' failed with error: " + error.toString())
+        });
   }
 
   /// Track a geolocation update.
@@ -54,8 +53,7 @@ class BatchProfile {
   /// your behalf. Acquire location permission and values on your own and
   /// communicate them to Batch (if needed) using this method.
   void trackLocation({required double latitude, required double longitude}) {
-    _channel.invokeMethod(
-        "profile.track.location", {"latitude": latitude, "longitude": longitude});
+    _channel.invokeMethod("profile.track.location", {"latitude": latitude, "longitude": longitude});
   }
 }
 
@@ -255,7 +253,8 @@ class BatchEventAttributes {
   /// While the value is an Uri instance, it must be a valid URL and
   /// not be longer than 2048 characters.
   BatchEventAttributes putUrl(String key, Uri value) {
-    _attributes[key.toLowerCase()] = TypedAttribute(type: TypedAttributeType.url, value: value.toString());
+    _attributes[key.toLowerCase()] =
+        TypedAttribute(type: TypedAttributeType.url, value: value.toString());
     return this;
   }
 
@@ -294,9 +293,8 @@ class BatchEventAttributes {
   /// Date attribute values are sent in UTC to Batch. If you notice that the reported
   /// time may be off, try making an UTC DateTime for consistency.
   BatchEventAttributes putDate(String key, DateTime value) {
-    _attributes[key.toLowerCase()] = TypedAttribute(
-        type: TypedAttributeType.date,
-        value: value.toUtc().millisecondsSinceEpoch);
+    _attributes[key.toLowerCase()] =
+        TypedAttribute(type: TypedAttributeType.date, value: value.toUtc().millisecondsSinceEpoch);
     return this;
   }
 
@@ -305,7 +303,8 @@ class BatchEventAttributes {
   /// The attribute key should be a string composed of letters, numbers
   /// or underscores (\[a-z0-9_\]) and can't be longer than 30 characters.
   BatchEventAttributes putObject(String key, BatchEventAttributes value) {
-    _attributes[key.toLowerCase()] = TypedAttribute(type: TypedAttributeType.object, value: value.internalGetBridgeRepresentation());
+    _attributes[key.toLowerCase()] = TypedAttribute(
+        type: TypedAttributeType.object, value: value.internalGetBridgeRepresentation());
     return this;
   }
 
@@ -318,7 +317,8 @@ class BatchEventAttributes {
     value.forEach((element) {
       array.add(element.internalGetBridgeRepresentation());
     });
-    _attributes[key.toLowerCase()] = TypedAttribute(type: TypedAttributeType.object_array, value: array);
+    _attributes[key.toLowerCase()] =
+        TypedAttribute(type: TypedAttributeType.object_array, value: array);
     return this;
   }
 
@@ -327,7 +327,8 @@ class BatchEventAttributes {
   /// The attribute key should be a string composed of letters, numbers
   /// or underscores (\[a-z0-9_\]) and can't be longer than 30 characters.
   BatchEventAttributes putStringList(String key, List<String> value) {
-    _attributes[key.toLowerCase()] = TypedAttribute(type: TypedAttributeType.string_array, value: value);
+    _attributes[key.toLowerCase()] =
+        TypedAttribute(type: TypedAttributeType.string_array, value: value);
     return this;
   }
 

--- a/lib/batch_push.dart
+++ b/lib/batch_push.dart
@@ -1,19 +1,16 @@
-import 'package:flutter/foundation.dart'
-    show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/services.dart';
 
 /// Provides push related functionality.
 /// Do not instanciate this: use the `instance` static property.
 class BatchPush {
-  static const MethodChannel _channel =
-      const MethodChannel('batch_flutter.push');
+  static const MethodChannel _channel = const MethodChannel('batch_flutter.push');
 
   /// Batch User module singleton.
   static BatchPush instance = new BatchPush();
 
   /// True when running on Android.
-  static bool get _isAndroidPlatform =>
-      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+  static bool get _isAndroidPlatform => !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
 
   /// Get the last known push token.
   /// This might be null if the SDK never successfully registered to push notifcations.
@@ -79,8 +76,8 @@ class BatchPush {
   ///
   /// Default: false
   void setShowForegroundNotificationsOniOS(bool showForegroundNotifications) {
-    _channel.invokeMethod('push.iOS.setShowForegroundNotifications',
-        {'enabled': showForegroundNotifications});
+    _channel.invokeMethod(
+        'push.iOS.setShowForegroundNotifications', {'enabled': showForegroundNotifications});
   }
 
   /// Android only. Controls whether Batch should display notifications.
@@ -88,8 +85,7 @@ class BatchPush {
     if (!_isAndroidPlatform) {
       return;
     }
-    await _channel.invokeMethod(
-        'push.setShowNotifications', {'enabled': showNotifications});
+    await _channel.invokeMethod('push.setShowNotifications', {'enabled': showNotifications});
   }
 
   /// Android only. Returns whether Batch currently shows notifications.

--- a/lib/batch_push.dart
+++ b/lib/batch_push.dart
@@ -41,6 +41,20 @@ class BatchPush {
     _channel.invokeMethod('push.requestPermission');
   }
 
+  /// Call this method to trigger the iOS/Android 13 popup that asks the user if they want
+  /// to allow notifications to be displayed.
+  /// You should call this at a strategic moment, like at the end of your onboarding.
+  ///
+  /// Returns a [Future] that resolves to `true` if the user granted
+  /// notification permission, `false` otherwise.
+  ///
+  /// iOS specific: You will then be able to get a push token: Batch will
+  /// automatically ask for a push token if the user replies positively.
+  /// The default registration is made with Badge, Sound and Alert.
+  Future<bool?> requestNotificationAuthorizationAsync() async {
+    return await _channel.invokeMethod<bool>('push.requestPermissionAsync');
+  }
+
   /// Call this method to ask iOS for a provisional notification authorization.
   /// Batch will then automatically ask for a push token. This does not do anything
   /// on Android.
@@ -74,8 +88,8 @@ class BatchPush {
     if (!_isAndroidPlatform) {
       return;
     }
-    await _channel.invokeMethod('push.setShowNotifications',
-        {'enabled': showNotifications});
+    await _channel.invokeMethod(
+        'push.setShowNotifications', {'enabled': showNotifications});
   }
 
   /// Android only. Returns whether Batch currently shows notifications.

--- a/lib/batch_user.dart
+++ b/lib/batch_user.dart
@@ -3,8 +3,7 @@ import 'package:flutter/services.dart';
 /// Provides user related functionality, such as custom data and events.
 /// Do not instantiate this: use the `instance` static property.
 class BatchUser {
-  static const MethodChannel _channel =
-      const MethodChannel('batch_flutter.user');
+  static const MethodChannel _channel = const MethodChannel('batch_flutter.user');
 
   /// Batch User module singleton.
   static BatchUser instance = new BatchUser();
@@ -36,7 +35,7 @@ class BatchUser {
   /// returned by [attributes] and [tagCollections].
   /// This does not affect data set on profiles using [BatchProfile].
   void clearInstallationData() {
-     _channel.invokeMethod('user.clearInstallationData');
+    _channel.invokeMethod('user.clearInstallationData');
   }
 
   /// Read the saved attributes.
@@ -64,8 +63,7 @@ class BatchUser {
         case "d":
           type = BatchUserAttributeType.date;
           int rawDate = rawValue as int;
-          castedValue =
-              DateTime.fromMillisecondsSinceEpoch(rawDate, isUtc: true);
+          castedValue = DateTime.fromMillisecondsSinceEpoch(rawDate, isUtc: true);
           break;
         case "i":
           type = BatchUserAttributeType.integer;

--- a/lib/src/inbox_fetcher.dart
+++ b/lib/src/inbox_fetcher.dart
@@ -6,8 +6,7 @@ import 'package:flutter/widgets.dart';
 /// <nodoc>
 @protected
 abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
-  static const MethodChannel _channel =
-      const MethodChannel('batch_flutter.inbox');
+  static const MethodChannel _channel = const MethodChannel('batch_flutter.inbox');
 
   bool _disposed = false;
   String? _fetcherID;
@@ -32,8 +31,8 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
   Future<BatchInboxFetchResult> fetchNewNotifications() async {
     _throwIfDisposed();
 
-    Map<String, dynamic>? response = await _channel.invokeMapMethod(
-        "inbox.fetchNewNotifications", _makeBaseBridgeParameters());
+    Map<String, dynamic>? response =
+        await _channel.invokeMapMethod("inbox.fetchNewNotifications", _makeBaseBridgeParameters());
 
     if (response == null) {
       throw InboxInternalError(code: 3);
@@ -48,8 +47,8 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
   Future<BatchInboxFetchResult> fetchNextPage() async {
     _throwIfDisposed();
 
-    Map<String, dynamic>? response = await _channel.invokeMapMethod(
-        "inbox.fetchNextPage", _makeBaseBridgeParameters());
+    Map<String, dynamic>? response =
+        await _channel.invokeMapMethod("inbox.fetchNextPage", _makeBaseBridgeParameters());
 
     if (response == null) {
       throw InboxInternalError(code: 3);
@@ -61,8 +60,7 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
   }
 
   @override
-  Future<void> markNotificationAsRead(
-      BatchInboxNotificationContent notification) async {
+  Future<void> markNotificationAsRead(BatchInboxNotificationContent notification) async {
     _throwIfDisposed();
 
     Map<String, dynamic> parameters = _makeBaseBridgeParameters();
@@ -74,13 +72,11 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
   Future<void> markAllNotificationsAsRead() async {
     _throwIfDisposed();
 
-    await _channel.invokeMethod(
-        "inbox.markAllAsRead", _makeBaseBridgeParameters());
+    await _channel.invokeMethod("inbox.markAllAsRead", _makeBaseBridgeParameters());
   }
 
   @override
-  Future<void> markNotificationAsDeleted(
-      BatchInboxNotificationContent notification) async {
+  Future<void> markNotificationAsDeleted(BatchInboxNotificationContent notification) async {
     _throwIfDisposed();
 
     Map<String, dynamic> parameters = _makeBaseBridgeParameters();
@@ -88,10 +84,8 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
     await _channel.invokeMethod("inbox.markAsDeleted", parameters);
   }
 
-
   @override
-  Future<void> displayNotificationLandingMessage(
-      BatchInboxNotificationContent notification) async {
+  Future<void> displayNotificationLandingMessage(BatchInboxNotificationContent notification) async {
     _throwIfDisposed();
 
     Map<String, dynamic> parameters = _makeBaseBridgeParameters();
@@ -103,8 +97,7 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
   void dispose() {
     _disposed = true;
     if (_fetcherID != null) {
-      _channel.invokeMethod(
-          'inbox.releaseFetcher', _makeBaseBridgeParameters());
+      _channel.invokeMethod('inbox.releaseFetcher', _makeBaseBridgeParameters());
     }
   }
 
@@ -145,13 +138,10 @@ abstract class BatchInboxFetcherBaseImpl extends BatchInboxFetcher {
       String? title = rawNotification["title"] as String?;
       String body = rawNotification["body"] as String;
       bool isUnread = rawNotification["isUnread"] as bool;
-      DateTime date =
-          DateTime.fromMillisecondsSinceEpoch(rawNotification["date"] as int)
-              .toUtc();
+      DateTime date = DateTime.fromMillisecondsSinceEpoch(rawNotification["date"] as int).toUtc();
       int rawSource = rawNotification["source"] as int;
       bool hasLandingMessage = rawNotification["hasLandingMessage"] as bool;
-      BatchInboxNotificationSource source =
-          BatchInboxNotificationSource.unknown;
+      BatchInboxNotificationSource source = BatchInboxNotificationSource.unknown;
       switch (rawSource) {
         case 1:
           source = BatchInboxNotificationSource.campaign;

--- a/lib/src/profile_attribute_editor.dart
+++ b/lib/src/profile_attribute_editor.dart
@@ -14,6 +14,9 @@ enum ProfileDataOperationKind {
   setEmailMarketingSubscription,
   setPhoneNumber,
   setSMSMarketingSubscription,
+  setTopicPreferences,
+  addToTopicPreferences,
+  removeFromTopicPreferences,
   setAttribute,
   removeAttribute,
   addToArray,
@@ -35,6 +38,12 @@ extension ProfileDataOperationKindBridge on ProfileDataOperationKind {
         return "SET_PHONE_NUMBER";
       case ProfileDataOperationKind.setSMSMarketingSubscription:
         return "SET_SMS_MARKETING_SUBSCRIPTION";
+      case ProfileDataOperationKind.setTopicPreferences:
+        return "SET_TOPIC_PREFERENCES";
+      case ProfileDataOperationKind.addToTopicPreferences:
+        return "ADD_TO_TOPIC_PREFERENCES";
+      case ProfileDataOperationKind.removeFromTopicPreferences:
+        return "REMOVE_FROM_TOPIC_PREFERENCES";
       case ProfileDataOperationKind.setAttribute:
         return "SET_ATTRIBUTE";
       case ProfileDataOperationKind.removeAttribute:
@@ -69,8 +78,10 @@ class ProfileDataOperation {
 @protected
 class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
   static final RegExp _attributeKeyRegexp = RegExp("^[a-zA-Z0-9_]{1,30}\$");
+  static final RegExp _topicPreferenceRegexp = RegExp("^[a-z0-9_]{1,300}\$");
   static const int _maxStringLength = 64;
   static const int _maxStringArrayLength = 25;
+  static const int _maxTopicPreferencesLength = 25;
 
   List<ProfileDataOperation> _operationQueue = [];
 
@@ -110,7 +121,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
     return this;
   }
-
 
   @override
   BatchProfileAttributeEditor setEmailAddress(String? address) {
@@ -154,6 +164,42 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
   BatchProfileAttributeEditor setSMSMarketingSubscription(BatchSMSSubscriptionState state) {
     _enqueueOperation(ProfileDataOperationKind.setSMSMarketingSubscription, {
       "value": state.name,
+    });
+    return this;
+  }
+
+  @override
+  BatchProfileAttributeEditor setTopicPreferences(List<String>? topics) {
+    if (topics != null && !_ensureValidTopicPreferences(topics)) {
+      return this;
+    }
+
+    _enqueueOperation(ProfileDataOperationKind.setTopicPreferences, {
+      "value": topics,
+    });
+    return this;
+  }
+
+  @override
+  BatchProfileAttributeEditor addToTopicPreferences(List<String> topics) {
+    if (!_ensureValidTopicPreferences(topics)) {
+      return this;
+    }
+
+    _enqueueOperation(ProfileDataOperationKind.addToTopicPreferences, {
+      "value": topics,
+    });
+    return this;
+  }
+
+  @override
+  BatchProfileAttributeEditor removeFromTopicPreferences(List<String> topics) {
+    if (!_ensureValidTopicPreferences(topics)) {
+      return this;
+    }
+
+    _enqueueOperation(ProfileDataOperationKind.removeFromTopicPreferences, {
+      "value": topics,
     });
     return this;
   }
@@ -361,6 +407,27 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
               "Ignoring operation on string '$item'.");
       return false;
     }
+    return true;
+  }
+
+  bool _ensureValidTopicPreferences(List<String> topics) {
+    if (topics.length > _maxTopicPreferencesLength) {
+      BatchLogger.public(
+          "BatchProfileAttributeEditor - Topic preferences cannot contain more than 25 items. " +
+              "Ignoring operation.");
+      return false;
+    }
+
+    for (String topic in topics) {
+      if (!_topicPreferenceRegexp.hasMatch(topic)) {
+        BatchLogger.public(
+            "BatchProfileAttributeEditor - Invalid topic preference '$topic'. " +
+                "Topic preferences must only contain lowercase letters, numbers or underscores " +
+                "and be 300 characters or less. Ignoring operation.");
+        return false;
+      }
+    }
+
     return true;
   }
 

--- a/lib/src/profile_attribute_editor.dart
+++ b/lib/src/profile_attribute_editor.dart
@@ -77,12 +77,6 @@ class ProfileDataOperation {
 /// <nodoc>
 @protected
 class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
-  static final RegExp _attributeKeyRegexp = RegExp("^[a-zA-Z0-9_]{1,30}\$");
-  static final RegExp _topicPreferenceRegexp = RegExp("^[a-z0-9_]{1,300}\$");
-  static const int _maxStringLength = 64;
-  static const int _maxStringArrayLength = 25;
-  static const int _maxTopicPreferencesLength = 25;
-
   List<ProfileDataOperation> _operationQueue = [];
 
   BatchProfileAttributeEditorImpl(MethodChannel userMethodChannel)
@@ -92,12 +86,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setLanguage(String? language) {
-    if (language != null && language.length == 0) {
-      BatchLogger.public("BatchProfileAttributeEditor - Language override cannot be empty. If " +
-          "you meant to un-set the language, please use null.");
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setLanguage, {
       "value": language,
     });
@@ -107,12 +95,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setRegion(String? region) {
-    if (region != null && region.length == 0) {
-      BatchLogger.public("BatchProfileAttributeEditor - Region override cannot be empty. If " +
-          "you meant to un-set the region, please use null.");
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setRegion, {
       "value": region,
     });
@@ -122,12 +104,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setEmailAddress(String? address) {
-    if (address != null && address.length == 0) {
-      BatchLogger.public("BatchProfileAttributeEditor - Email cannot be empty. If " +
-          "you meant to un-set the email, please use null.");
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setEmailAddress, {
       "value": address,
     });
@@ -144,12 +120,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setPhoneNumber(String? phoneNumber) {
-    if (phoneNumber != null && phoneNumber.length == 0) {
-      BatchLogger.public("BatchProfileAttributeEditor - phoneNumber cannot be empty. If " +
-          "you meant to un-set the phone number, please use null.");
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setPhoneNumber, {
       "value": phoneNumber,
     });
@@ -166,10 +136,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setTopicPreferences(List<String>? topics) {
-    if (topics != null && !_ensureValidTopicPreferences(topics)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setTopicPreferences, {
       "value": topics,
     });
@@ -178,10 +144,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor addToTopicPreferences(List<String> topics) {
-    if (!_ensureValidTopicPreferences(topics)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.addToTopicPreferences, {
       "value": topics,
     });
@@ -190,10 +152,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor removeFromTopicPreferences(List<String> topics) {
-    if (!_ensureValidTopicPreferences(topics)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.removeFromTopicPreferences, {
       "value": topics,
     });
@@ -202,14 +160,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor addToArray(String key, String value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
-    if (!_ensureValidStringItem(value)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.addToArray, {
       "key": key,
       "value": value,
@@ -220,14 +170,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor removeFromArray(String key, String value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
-    if (!_ensureValidStringItem(value)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.removeFromArray, {
       "key": key,
       "value": value,
@@ -238,10 +180,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setBooleanAttribute(String key, bool value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setAttribute, {
       "key": key,
       "type": "boolean",
@@ -253,88 +191,46 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setDateTimeAttribute(String key, DateTime value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setAttribute, {
       "key": key,
       "type": "date",
       "value": value.toUtc().millisecondsSinceEpoch,
     });
-
     return this;
   }
 
   @override
   BatchProfileAttributeEditor setDoubleAttribute(String key, double value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setAttribute, {
       "key": key,
       "type": "float",
       "value": value,
     });
-
     return this;
   }
 
   @override
   BatchProfileAttributeEditor setIntegerAttribute(String key, int value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setAttribute, {
       "key": key,
       "type": "integer",
       "value": value,
     });
-
     return this;
   }
 
   @override
   BatchProfileAttributeEditor setStringAttribute(String key, String value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
-    if (value.length <= _maxStringLength) {
-      _enqueueOperation(ProfileDataOperationKind.setAttribute, {
-        "key": key,
-        "type": "string",
-        "value": value,
-      });
-    } else {
-      BatchLogger.public("BatchProfileAttributeEditor - Invalid attribute string value. String " +
-          "attributes cannot be longer than 64 characters (bytes). " +
-          "Ignoring attribute '$key'.");
-    }
-
+    _enqueueOperation(ProfileDataOperationKind.setAttribute, {
+      "key": key,
+      "type": "string",
+      "value": value,
+    });
     return this;
   }
 
   @override
   BatchProfileAttributeEditor setStringListAttribute(String key, List<String> value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-    if (value.length > _maxStringArrayLength) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - List of string attributes must not be longer than 25 items. " +
-              "Ignoring attribute '$key'.");
-    }
-    for (String item in value) {
-      if (!_ensureValidStringItem(item)) {
-        BatchLogger.public(
-            "BatchProfileAttributeEditor - List of string attributes must respect the string attribute limitations. " +
-                "Ignoring attribute '$key'.");
-        return this;
-      }
-    }
     _enqueueOperation(ProfileDataOperationKind.setAttribute, {
       "key": key,
       "type": "array",
@@ -345,25 +241,16 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
   @override
   BatchProfileAttributeEditor setUrlAttribute(String key, Uri value) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.setAttribute, {
       "key": key,
       "type": "url",
       "value": value.toString(),
     });
-
     return this;
   }
 
   @override
   BatchProfileAttributeEditor removeAttribute(String key) {
-    if (!_ensureValidAttributeKey(key)) {
-      return this;
-    }
-
     _enqueueOperation(ProfileDataOperationKind.removeAttribute, {
       "key": key,
     });
@@ -378,49 +265,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
     };
     _operationQueue.clear();
     _userMethodChannel.invokeMethod("profile.edit", bridgeOperations);
-  }
-
-  bool _ensureValidAttributeKey(String key) {
-    if (!_attributeKeyRegexp.hasMatch(key)) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - Invalid attribute key. Please make sure that " +
-              "the key is made of letters, underscores and numbers only " +
-              "(a-zA-Z0-9_). It also can't be longer than 30 characters. " +
-              "Ignoring attribute '$key'.");
-      return false;
-    }
-    return true;
-  }
-
-  bool _ensureValidStringItem(String item) {
-    if (item.length == 0 || item.length > _maxStringLength) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - Invalid string item. String items are not allowed to " +
-              "be longer than 64 characters (bytes) and must not be empty. " +
-              "Ignoring operation on string '$item'.");
-      return false;
-    }
-    return true;
-  }
-
-  bool _ensureValidTopicPreferences(List<String> topics) {
-    if (topics.length > _maxTopicPreferencesLength) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - Topic preferences cannot contain more than 25 items. " +
-              "Ignoring operation.");
-      return false;
-    }
-
-    for (String topic in topics) {
-      if (!_topicPreferenceRegexp.hasMatch(topic)) {
-        BatchLogger.public("BatchProfileAttributeEditor - Invalid topic preference '$topic'. " +
-            "Topic preferences must only contain lowercase letters, numbers or underscores " +
-            "and be 300 characters or less. Ignoring operation.");
-        return false;
-      }
-    }
-
-    return true;
   }
 
   void _enqueueOperation(ProfileDataOperationKind kind, Map<String, dynamic> arguments) {

--- a/lib/src/profile_attribute_editor.dart
+++ b/lib/src/profile_attribute_editor.dart
@@ -93,9 +93,8 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
   @override
   BatchProfileAttributeEditor setLanguage(String? language) {
     if (language != null && language.length == 0) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - Language override cannot be empty. If " +
-              "you meant to un-set the language, please use null.");
+      BatchLogger.public("BatchProfileAttributeEditor - Language override cannot be empty. If " +
+          "you meant to un-set the language, please use null.");
       return this;
     }
 
@@ -109,9 +108,8 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
   @override
   BatchProfileAttributeEditor setRegion(String? region) {
     if (region != null && region.length == 0) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - Region override cannot be empty. If " +
-              "you meant to un-set the region, please use null.");
+      BatchLogger.public("BatchProfileAttributeEditor - Region override cannot be empty. If " +
+          "you meant to un-set the region, please use null.");
       return this;
     }
 
@@ -125,9 +123,8 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
   @override
   BatchProfileAttributeEditor setEmailAddress(String? address) {
     if (address != null && address.length == 0) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - Email cannot be empty. If " +
-              "you meant to un-set the email, please use null.");
+      BatchLogger.public("BatchProfileAttributeEditor - Email cannot be empty. If " +
+          "you meant to un-set the email, please use null.");
       return this;
     }
 
@@ -148,9 +145,8 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
   @override
   BatchProfileAttributeEditor setPhoneNumber(String? phoneNumber) {
     if (phoneNumber != null && phoneNumber.length == 0) {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - phoneNumber cannot be empty. If " +
-              "you meant to un-set the phone number, please use null.");
+      BatchLogger.public("BatchProfileAttributeEditor - phoneNumber cannot be empty. If " +
+          "you meant to un-set the phone number, please use null.");
       return this;
     }
 
@@ -313,10 +309,9 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
         "value": value,
       });
     } else {
-      BatchLogger.public(
-          "BatchProfileAttributeEditor - Invalid attribute string value. String " +
-              "attributes cannot be longer than 64 characters (bytes). " +
-              "Ignoring attribute '$key'.");
+      BatchLogger.public("BatchProfileAttributeEditor - Invalid attribute string value. String " +
+          "attributes cannot be longer than 64 characters (bytes). " +
+          "Ignoring attribute '$key'.");
     }
 
     return this;
@@ -333,7 +328,7 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
               "Ignoring attribute '$key'.");
     }
     for (String item in value) {
-      if(!_ensureValidStringItem(item)) {
+      if (!_ensureValidStringItem(item)) {
         BatchLogger.public(
             "BatchProfileAttributeEditor - List of string attributes must respect the string attribute limitations. " +
                 "Ignoring attribute '$key'.");
@@ -347,7 +342,6 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
     });
     return this;
   }
-
 
   @override
   BatchProfileAttributeEditor setUrlAttribute(String key, Uri value) {
@@ -380,8 +374,7 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
   @override
   void save() {
     Map bridgeOperations = {
-      "operations":
-          _operationQueue.map((e) => e.toBridgeRepresentation()).toList(),
+      "operations": _operationQueue.map((e) => e.toBridgeRepresentation()).toList(),
     };
     _operationQueue.clear();
     _userMethodChannel.invokeMethod("profile.edit", bridgeOperations);
@@ -420,10 +413,9 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
 
     for (String topic in topics) {
       if (!_topicPreferenceRegexp.hasMatch(topic)) {
-        BatchLogger.public(
-            "BatchProfileAttributeEditor - Invalid topic preference '$topic'. " +
-                "Topic preferences must only contain lowercase letters, numbers or underscores " +
-                "and be 300 characters or less. Ignoring operation.");
+        BatchLogger.public("BatchProfileAttributeEditor - Invalid topic preference '$topic'. " +
+            "Topic preferences must only contain lowercase letters, numbers or underscores " +
+            "and be 300 characters or less. Ignoring operation.");
         return false;
       }
     }
@@ -431,8 +423,7 @@ class BatchProfileAttributeEditorImpl implements BatchProfileAttributeEditor {
     return true;
   }
 
-  void _enqueueOperation(
-      ProfileDataOperationKind kind, Map<String, dynamic> arguments) {
+  void _enqueueOperation(ProfileDataOperationKind kind, Map<String, dynamic> arguments) {
     _operationQueue.add(ProfileDataOperation(kind: kind, arguments: arguments));
   }
 }

--- a/lib/src/typed_attribute.dart
+++ b/lib/src/typed_attribute.dart
@@ -19,7 +19,17 @@ class TypedAttribute {
 /// A typed attribute's type
 /// <nodoc>
 @protected
-enum TypedAttributeType { string, boolean, integer, float, date, url, object, string_array, object_array }
+enum TypedAttributeType {
+  string,
+  boolean,
+  integer,
+  float,
+  date,
+  url,
+  object,
+  string_array,
+  object_array
+}
 
 extension TypedAttributeTypeBridge on TypedAttributeType {
   String toBridgeRepresentation() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: batch_flutter
 description: Batch SDK Flutter Plugin allows you to build meaningful communication experiences in your app through highly personalized push notifications and In-App messages.
-version: 3.0.0
+version: 3.1.0
 homepage: https://batch.com
 
 environment:


### PR DESCRIPTION
## 3.1.0

**Plugin**
- Updated Batch to 3.3

**Profile**
- Added `setTopicPreferences(List<String>? topics)` to `BatchProfileAttributeEditor` class to set or reset the profile topic preferences.
- Added `addToTopicPreferences(List<String> topics)` to `BatchProfileAttributeEditor` class to add topics to the profile topic preferences.
- Added `removeFromTopicPreferences(List<String> topics)` to `BatchProfileAttributeEditor` class to remove topics from the profile topic preferences.
- Profile string attributes now support up to 300 characters for the Customer Engagement Platform (CEP). The limit for the Mobile Engagement Platform (MEP) remains 64 characters. Attributes set via `BatchProfileAttributeEditor.setStringAttribute()` longer than 64 characters will only be applied to the CEP.
- Event string attributes now support up to 300 characters for the Customer Engagement Platform (CEP). The limit for the Mobile Engagement Platform (MEP) remains 200 characters. Attributes set via `BatchEventAttributes.putString()` longer than 200 characters will only be applied to the CEP.

**Push**
- Added `requestNotificationAuthorizationAsync()`to request notification authorization and return a promise that resolve with the authorization result.